### PR TITLE
Update ubuntu_pymupdf.sh

### DIFF
--- a/installation/ubuntu/ubuntu_pymupdf.sh
+++ b/installation/ubuntu/ubuntu_pymupdf.sh
@@ -1,9 +1,11 @@
-wget https://mupdf.com/downloads/mupdf-1.13.0-source.tar.gz
-tar -zxvf mupdf-1.13.0-source.tar.gz
+wget https://mupdf.com/downloads/mupdf-1.14.0-source.tar.gz
+tar -zxvf mupdf-1.14.0-source.tar.gz
 
-cd mupdf-1.13.0-source
+cd mupdf-1.14.0-source
 
 export CFLAGS="-fPIC"
+# install some prerequirement
+sudo apt install pkg-config python-dev zlib1g zlib1g-dev
 
 make HAVE_X11=no HAVE_GLFW=no HAVE_GLUT=no prefix=/usr/local
 sudo make HAVE_X11=no HAVE_GLFW=no HAVE_GLUT=no prefix=/usr/local install


### PR DESCRIPTION
Current PyMuPDF should build with mupdf-1.14.0
Add some prerequirement when build under Ubuntu OS