### PR TITLE
Prevent docs .ico build warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ html_theme_options = {
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = "pymupdf.ico"
+html_favicon = "PyMuPDF.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
A system with a case sensitive file system will show:
WARNING: favicon file 'pymupdf.ico' does not exist