### PR TITLE
Loads libraries to link with based on /etc/os-release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup, Extension
 from distutils.command.build_py import build_py as build_py_orig
-import sys, os
+import re, sys, os
 
 # custom build_py command which runs build_ext first
 # this is necessary because build_py needs the fitz.py which is only generated
@@ -9,6 +9,35 @@ class build_ext_first(build_py_orig):
     def run(self):
         self.run_command("build_ext")
         return super().run()
+
+
+DEFAULT = ["mupdf", "mupdf-third"]
+ARCH_LINUX = DEFAULT + ["jbig2dec", "openjp2", "jpeg", "freetype"]
+OPENSUSE = ARCH_LINUX + ["harfbuzz", "png16"]
+LIBRARIES = {
+    "default": DEFAULT,
+    "arch": ARCH_LINUX,
+    "opensuse": OPENSUSE,
+}
+
+
+def load_libraries():
+    filepath = "/etc/os-release"
+    if not os.path.exists(filepath):
+        return LIBRARIES["default"]
+    regex = re.compile("^([\\w]+)=(?:'|\")?(.*?)(?:'|\")?$")
+    with open(filepath) as os_release:
+        info = {regex.match(line.strip()).group(1): re.sub(
+                    r'\\([$"\'\\`])', r"\1",
+                    regex.match(line.strip()).group(2))
+                for line in os_release if regex.match(line.strip())}
+
+    os_id = info["ID"]
+    if os_id.startswith("opensuse"):
+        os_id = "opensuse"
+    if os_id not in LIBRARIES:
+        return LIBRARIES["default"]
+    return LIBRARIES[os_id]
 
 
 # check the platform
@@ -20,13 +49,7 @@ if sys.platform.startswith("linux"):
             "/usr/include/mupdf",
             "/usr/local/include/mupdf",
         ],
-        # library_dirs=['<mupdf_and_3rd_party_libraries_dir>'],
-        libraries=[
-            "mupdf",
-            # 'crypto', #openssl is required by mupdf on archlinux
-            'jbig2dec', 'openjp2', 'jpeg', 'freetype', 'harfbuzz', 'png16',
-            "mupdf-third",
-        ],  # the libraries to link with
+        libraries=load_libraries()
     )
 elif sys.platform.startswith(("darwin", "freebsd")):
     module = Extension(

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ if sys.platform.startswith("linux"):
         # library_dirs=['<mupdf_and_3rd_party_libraries_dir>'],
         libraries=[
             "mupdf",
-            #'crypto', #openssl is required by mupdf on archlinux
-            #'jbig2dec', 'openjp2', 'jpeg', 'freetype',
+            # 'crypto', #openssl is required by mupdf on archlinux
+            'jbig2dec', 'openjp2', 'jpeg', 'freetype', 'harfbuzz', 'png16',
             "mupdf-third",
         ],  # the libraries to link with
     )


### PR DESCRIPTION
This PR adds a function `load_libraries` which loads the libraries to link with based on `/etc/os-releaes`. The default libraries are: `["mupdf", "mupdf-third"]`

I have tested it manually on openSUSE 15.1 and ArchLinux. @JorjMcKie Do you want more tests. How do you usually test pymupdf locally?

Fixes: #574 