### PR TITLE
Load libraries on Fedora

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,12 @@ class build_ext_first(build_py_orig):
 DEFAULT = ["mupdf", "mupdf-third"]
 ARCH_LINUX = DEFAULT + ["jbig2dec", "openjp2", "jpeg", "freetype"]
 OPENSUSE = ARCH_LINUX + ["harfbuzz", "png16"]
+FEDORA = ARCH_LINUX + ["harfbuzz"]
 LIBRARIES = {
     "default": DEFAULT,
     "arch": ARCH_LINUX,
     "opensuse": OPENSUSE,
+    "fedora": FEDORA,
 }
 
 


### PR DESCRIPTION
This pull request is related to https://github.com/pymupdf/PyMuPDF/issues/574. Based on https://github.com/pymupdf/PyMuPDF/pull/577, this commit also detects Fedora and loads needed libraries. Tested on Fedora 32.

I also want to add Ubuntu support, but since Travis uses Ubuntu to build, I am not sure if linking additional libraries will affect builds. I am not familiar with Travis, maybe setup.py also needs to detect travis?