### PR TITLE
Build on any GNU system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def load_libraries():
 
 
 # check the platform
-if sys.platform.startswith("linux"):
+if sys.platform.startswith("linux") or 'gnu' in sys.platform:
     module = Extension(
         "fitz._fitz",  # name of the module
         ["fitz/fitz.i"],


### PR DESCRIPTION
The toolchain of GNU systems mostly is the same as the ones used on Linux, so share the build settings.