### PR TITLE
Use premultiplied alpha format for QImage conversion

### DIFF
--- a/docs/multiprocess-gui.py
+++ b/docs/multiprocess-gui.py
@@ -122,7 +122,7 @@ class DocForm(QtWidgets.QWidget):
                 self.curPageNum = num
                 self.label.setText("{}/{}".format(self.curPageNum + 1, self.pageCount))
                 fmt = (
-                    QtGui.QImage.Format_RGBA8888
+                    QtGui.QImage.Format_RGBA8888_Premultiplied
                     if alpha
                     else QtGui.QImage.Format_RGB888
                 )

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -201,7 +201,7 @@ Again, you also can get along **without using PIL** if you use the pixmap *strid
     from PyQt<x>.QtGui import QImage
 
     # set the correct QImage format depending on alpha
-    fmt = QImage.Format_RGBA8888 if pix.alpha else QImage.Format_RGB888
+    fmt = QImage.Format_RGBA8888_Premultiplied if pix.alpha else QImage.Format_RGB888
     qtimg = QImage(pix.samples, pix.width, pix.height, pix.stride, fmt)
 
 


### PR DESCRIPTION
The Pixmap from pymupdf uses a premultiplied alpha channel (when alpha channel is available). When converting that to Qt's QImage, the proper format  ``Format_RGBA8888_Premultiplied`` rather than ``Format_RGBA8888``.

This can be verified by the following script.

```python
import fitz
from PyQt5.QtGui import QImage

doc = fitz.Document()
page = doc.newPage()

rect_annot = page.addRectAnnot((100, 100, 200, 200))
rect_annot.setColors(fill=(1.0, 0, 0))
rect_annot.update(opacity=0.5)

pixmap_rect = rect_annot.getPixmap(alpha=True)
pixmap_rect.writeImage(filename="from_fitz.png")

print(pixmap_rect.pixel(10, 10))

image = QImage(pixmap_rect.samples, pixmap_rect.width, pixmap_rect.height, pixmap_rect.stride, QImage.Format_RGBA8888)
image.save("from_qt.png")
image = QImage(pixmap_rect.samples, pixmap_rect.width, pixmap_rect.height, pixmap_rect.stride, QImage.Format_RGBA8888_Premultiplied)
image.save("from_qt_premultiplied.png")
```

1. You can see the printed pixel is `(126, 0, 0, 126)` showing that the pixel format is indeed premultiplied
2. `from_fitz.png` is identical to `from_qt_premultiplied.png`, but `from_qt.png` is notably dimmer.

