### PR TITLE
build against system gumbo library on Fedora

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ class build_ext_first(build_py_orig):
 DEFAULT = ["mupdf", "mupdf-third"]
 ARCH_LINUX = DEFAULT + ["jbig2dec", "openjp2", "jpeg", "freetype"]
 OPENSUSE = ARCH_LINUX + ["harfbuzz", "png16"]
-FEDORA = ARCH_LINUX + ["harfbuzz"]
+FEDORA = ARCH_LINUX + ["harfbuzz", "gumbo"]
 LIBRARIES = {
     "default": DEFAULT,
     "arch": ARCH_LINUX,


### PR DESCRIPTION
On Fedora, we build mupdf against as many system libraries as possible (all but the ones patched by Artifex). This includes the gumbo parser lib.

This is not the only change which PyMuPDF 1.18.0 requires: Since 1.17.5 PyMuPDF requires to be built against patched mupdf sources which really is a no-go.

For now, I'm including the patch for jm_valid_chars() into mupdf packages in Fedora so that - together with this PR for PyMuPDF - the package PyMuPDF can stay in Fedora.

But please do not make this into a habit. It creates packaging nightmares, and mupdf is developping its own python bindings in the 1.18 series. So I suggest upstreaming jm_valid_chars() (that snippet is used in mupdf anyways, just not as a separate function yet) or using the new binding.