### PR TITLE
Don't decode streams in utils.scrub

### DIFF
--- a/fitz/utils.py
+++ b/fitz/utils.py
@@ -3467,23 +3467,23 @@ def scrub(
         suppress = False  # indicate text suppression active
         make_return = False
         for line in cont_lines:
-            if line == "BT":  # start of text object
+            if line == b"BT":  # start of text object
                 in_text = True  # switch on
                 out_lines.append(line)  # output it
                 continue
-            if line == "ET":  # end of text object
+            if line == b"ET":  # end of text object
                 in_text = False  # switch off
                 out_lines.append(line)  # output it
                 continue
-            if line == "3 Tr":  # text suppression operator
+            if line == b"3 Tr":  # text suppression operator
                 suppress = True  # switch on
                 make_return = True
                 continue
-            if line[-2:] == "Tr" and line[0] != "3":
+            if line[-2:] == b"Tr" and line[0] != b"3":
                 suppress = False  # text rendering changed
                 out_lines.append(line)
                 continue
-            if line == "Q":  # unstack command also switches off
+            if line == b"Q":  # unstack command also switches off
                 suppress = False
                 out_lines.append(line)
                 continue
@@ -3578,10 +3578,10 @@ def scrub(
 
         if hidden_text:
             xref = page.getContents()[0]  # only one b/o cleaning!
-            cont = doc.xrefStream(xref).decode()  # /Contents converted to str
+            cont = doc.xrefStream(xref)  # /Contents as bytes
             cont_lines = remove_hidden(cont.splitlines())  # remove hidden text
             if cont_lines:  # something was actually removed
-                cont = "\n".join(cont_lines).encode()
+                cont = b"\n".join(cont_lines)
                 doc.updateStream(xref, cont)  # rewrite the page /Contents
 
 


### PR DESCRIPTION
In `utils.scrub`, when removing hidden text, there is an attempt to UTF-8 decode the `\Contents` stream, which is not necessarily possible since it also contains text strings which according to the official reference guide can be arbitrary byte arrays.

The proposed changes address the issue by comparing the byte arrays without decoding.

Quote from section 5.3.2 of the [official reference guide](https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdf_reference_archive/pdf_reference_1-7.pdf):

_The strings must conform to the syntax for string objects. When a string is written by enclosing the data in parentheses, bytes whose values are the same as those of the ASCII characters left parenthesis (40), right parenthesis (41), and backslash (92) must be preceded by a backslash character. **All other byte values between 0 and 255 may be used in a string object.** These rules apply to each individual byte in a string object, whether the string is interpreted by the text-showing operators as single-byte or multiple-byte character codes._