### PR TITLE
Add include path for freetype on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ if sys.platform.startswith("linux") or 'gnu' in sys.platform:
         include_dirs=[  # we need the path of the MuPDF headers
             "/usr/include/mupdf",
             "/usr/local/include/mupdf",
+            "/usr/include/freetype2",
         ],
         libraries=load_libraries(),
     )


### PR DESCRIPTION
I had to do this to get 1.18.1 to compile on Fedora.