### PR TITLE
fix incorrect func calls witihin `Pixmap().pillowData()`

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -6661,8 +6661,8 @@ def pillowData(self, *args, **kwargs):
     """
     from io import BytesIO
     bytes_out = BytesIO()
-    self.pillowSave(bytes_out, *args, **kwargs)
-    return bytes_out.get_value()
+    self.pillowWrite(bytes_out, *args, **kwargs)
+    return bytes_out.getvalue()
 
         %}
         //----------------------------------------------------------------------


### PR DESCRIPTION
Trying to use `pillowData("JPEG")` and I got some errors. The proposed changes allow for expected usage of `pillowData()`