### PR TITLE
Fix return value order in appendix 2

### DIFF
--- a/docs/app2.rst
+++ b/docs/app2.rst
@@ -46,7 +46,7 @@ BLOCKS
 
 Function :meth:`TextPage.extractBLOCKS` (or *Page.getText("blocks")*) extracts a page's text blocks as a list of items like::
 
-    (x0, y0, x1, y1, "lines in block", block_type, block_no)
+    (x0, y0, x1, y1, "lines in block", block_no, block_type)
 
 Where the first 4 items are the float coordinates of the block's bbox. The lines within each block are concatenated by a new-line character.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -298,7 +298,7 @@ More can be found in the :ref:`Document` chapter. Also have a look at `PDFjoiner
 Embedding Data
 ---------------
 
-PDFs can be used as containers for abitrary data (executables, other PDFs, text or binary files, etc.) much like ZIP archives.
+PDFs can be used as containers for arbitrary data (executables, other PDFs, text or binary files, etc.) much like ZIP archives.
 
 PyMuPDF fully supports this feature via :ref:`Document` *embeddedFile** methods and attributes. For some detail read :ref:`Appendix 3`, consult the Wiki on `embedding files <https://github.com/pymupdf/PyMuPDF/wiki/Dealing-with-Embedded-Files>`_, or the example scripts `embedded-copy.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-copy.py>`_, `embedded-export.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-export.py>`_, `embedded-import.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-import.py>`_, and `embedded-list.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-list.py>`_.
 


### PR DESCRIPTION
The correct argument order is shown in [the source code](https://github.com/pymupdf/PyMuPDF/blob/master/fitz/fitz.i#L9831) and [a documentation file](https://github.com/pymupdf/PyMuPDF/blob/master/docs/textpage.rst).