### PR TITLE
allow conversion from PDF to PDF

### DIFF
--- a/docs/document.rst
+++ b/docs/document.rst
@@ -625,7 +625,7 @@ For details on **embedded files** refer to Appendix 3.
 
     .. method:: convertToPDF(from_page=-1, to_page=-1, rotate=0)
 
-      Create a PDF version of the current document and write it to memory. **All document types** (except PDF) are supported. The parameters have the same meaning as in :meth:`insert_pdf`. In essence, you can restrict the conversion to a page subset, specify page rotation, and revert page sequence.
+      Create a PDF version of the current document and write it to memory. **All document types** are supported. The parameters have the same meaning as in :meth:`insert_pdf`. In essence, you can restrict the conversion to a page subset, specify page rotation, and revert page sequence.
 
       :arg int from_page: first page to copy (0-based). Default is first page.
 

--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -1124,8 +1124,6 @@ struct Document
             fz_document *fz_doc = (fz_document *) $self;
             fz_try(gctx) {
                 int fp = from_page, tp = to_page, srcCount = fz_count_pages(gctx, fz_doc);
-                if (pdf_specifics(gctx, fz_doc))
-                    THROWMSG(gctx, "bad document type");
                 if (fp < 0) fp = 0;
                 if (fp > srcCount - 1) fp = srcCount - 1;
                 if (tp < 0) tp = srcCount - 1;


### PR DESCRIPTION
`mutool convert` allows PDF as input and output type. There is no sense
in forbidding this action in the python library. A possible use case
for converting a PDF to a PDF using mupdf is rendering PDF form widgets
as PDF text.