### PR TITLE
update return typing of Document.pages

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -4072,7 +4072,7 @@ if basestate:
                 return self.delete_pages(range(start, stop, step))
 
 
-            def pages(self, start: OptInt =None, stop: OptInt =None, step: OptInt =None)->"Page":
+            def pages(self, start: OptInt =None, stop: OptInt =None, step: OptInt =None)->Generator["Page"]:
                 """Return a generator iterator over a page range.
 
                 Arguments have the same meaning as for the range() built-in.

--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -4072,7 +4072,7 @@ if basestate:
                 return self.delete_pages(range(start, stop, step))
 
 
-            def pages(self, start: OptInt =None, stop: OptInt =None, step: OptInt =None)->Generator["Page"]:
+            def pages(self, start: OptInt =None, stop: OptInt =None, step: OptInt =None)->typing.Generator["Page"]:
                 """Return a generator iterator over a page range.
 
                 Arguments have the same meaning as for the range() built-in.


### PR DESCRIPTION
Since the typing state that pages return a "Page", typechecker raise warnings when using Document.pages() in a forloop.