### PR TITLE
Build with tesseract/leptonica on Fedora

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ OPENSUSE = ARCH_LINUX + [
 ]
 FEDORA = ARCH_LINUX + [
     "harfbuzz",
+    "leptonica",
+    "tesseract",
 ]
 NIX = ARCH_LINUX + ["harfbuzz"]
 LIBRARIES = {


### PR DESCRIPTION
Others might want to do the same as soon as mupdf is packaged with OCR
support.