### PR TITLE
Fix Example

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1421,7 +1421,7 @@ The following is a code snippet which extracts the drawings of a page and re-dra
             elif item[0] == "re":  # rectangle
                 shape.draw_rect(item[1])
             elif item[0] == "qu":  # quad
-                shape.draw_rect(item[1])
+                shape.draw_quad(item[1])
             elif item[0] == "c":  # curve
                 shape.draw_bezier(item[1], item[2], item[3], item[4])
             else:


### PR DESCRIPTION
Small fix for one the example snippets in the FAQ.

`draw_rect` results in `ValueError: bad operand type`, so we should use `draw_quad` instead.