### PR TITLE
Update link to wheels-upto-Py3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There are **no mandatory** external dependencies. However, some **optional featu
 * [Tesseract-OCR](https://github.com/tesseract-ocr/tesseract) for optical character recognition in images and document pages. Tesseract is separate software, not a Python package. To enable OCR functions in PyMuPDF, the system environment variable `"TESSDATA_PREFIX"` must be defined and contain the `tessdata` folder name of the Tesseract installation location.
 
 
-Older wheels - also with support for older Python versions - can be found [here](https://github.com/pymupdf/PyMuPDF-Optional-Material/tree/master/wheels-upto-Py3.5>) and on PyPI.
+Older wheels - also with support for older Python versions - can be found [here](https://github.com/pymupdf/PyMuPDF-Optional-Material/tree/master/wheels-upto-Py3.5) and on PyPI.
 
 Other platforms **require installation from sources**, follow [these](https://pymupdf.readthedocs.io/en/latest/installation.html) instructions in the documentation.
 


### PR DESCRIPTION
In sub-section 'Installation' of README.md, the link to older wheels for unmaintained Python versions had a small typo.