### PR TITLE
Adds rst2pdf to doc requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 docutils<0.16
+rst2pdf


### PR DESCRIPTION
This should hopefully allow readthedocs to import the 
module and successfully build