### PR TITLE
Setup for Google Tag Manager within docs

### DIFF
--- a/docs/_static/app.js
+++ b/docs/_static/app.js
@@ -1,0 +1,21 @@
+// <!-- This goes in the head -->
+// <!-- Google Tag Manager -->
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NR2RWK5');
+// <!-- End Google Tag Manager -->
+
+// <!-- This goes in the body -->
+document.addEventListener("DOMContentLoaded", function(event) {
+    var firstBodyDiv = document.body.childNodes[0];
+
+    var gtmScript   = document.createElement("script");
+    gtmScript.type  = "text/javascript";
+    gtmScript.text  = '<!-- Google Tag Manager (noscript) -->'; // inline script
+    gtmScript.text += '<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NR2RWK5"';
+    gtmScript.text += 'height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>';
+    gtmScript.text += '<!-- End Google Tag Manager (noscript) -->';
+    firstBodyDiv.before(gtmScript);
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,6 +129,9 @@ html_static_path = ["_static"]
 # relative to the html_static_path, or a full URI
 html_css_files = ['custom.css']
 
+# A way of embedding your own JS in the <head>
+html_js_files = ['app.js']
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.


### PR DESCRIPTION
This included js file ( app.js ) allows us to inject the javascript
required for Google Tag Manager on every page of the
documentation.

Additionally, at a later time, if we require to inject any 
other JS for any other reason we can append to this file
as required.