### PR TITLE
Fix letter generation for page labels

### DIFF
--- a/fitz/utils.py
+++ b/fitz/utils.py
@@ -4735,11 +4735,16 @@ def integerToLetter(i) -> str:
     # William Chapman, Jorj McKie, 2021-01-06
 
     ls = string.ascii_uppercase
-    m = int((i - 1) / 26)  # how many times over
-    n = (i % 26) - 1  # remainder
+    n, a = 1, i
+    while pow(26, n) <= a:
+        a -= int(math.pow(26, n))
+        n += 1
+
     str_t = ""
-    for _ in range(0, m + 1):
-        str_t = str_t + ls[n]
+    for j in reversed(range(n)):
+        f, g = divmod(a, int(math.pow(26, j)))
+        str_t += ls[f]
+        a = g
     return str_t
 
 


### PR DESCRIPTION
The old code generates page labels like a,b,c,d,...,x,y,z,aa,bb,cc,... while it should be a,b,c,d...x,y,z,aa,ab,ac,... This code should also work for a number way bigger than what any reasonable individual would need for a pdf page label