### PR TITLE
Fixing #2013

### DIFF
--- a/fitz/helper-fields.i
+++ b/fitz/helper-fields.i
@@ -1030,8 +1030,7 @@ class Widget(object):
         return "'%s' widget on %s" % (self.field_type_string, str(self.parent))
 
     def __del__(self):
-        annot = getattr(self, "_annot")
-        if annot:
+        if hasattr(self, "_annot"):
             del self._annot
 
     @property


### PR DESCRIPTION
Additional safeguard when field is being deleted via `page.delete_widget()`: In this case, the underlying annotation may not have been re-established (attribute "_annot"), which will therefore be checked.

This should be included in the final version 1.21.0.