### PR TITLE
fitz/utils.py: fix #2051, added `dpi` arg in get_page_pixmap() and re…

### DIFF
--- a/docs/document.rst
+++ b/docs/document.rst
@@ -849,9 +849,11 @@ For details on **embedded files** refer to Appendix 3.
           '(Prices in EUR \\(USD also accepted\\). Areas are in m\\262.)'
 
 
-    .. method:: get_page_pixmap(pno, *args, **kwargs)
+    .. method:: get_page_pixmap(pno: int, *, matrix: matrix_like = Identity, dpi=None, colorspace: Colorspace = csRGB, clip: rect_like = None, alpha: bool = False, annots: bool = True)
 
       Creates a pixmap from page *pno* (zero-based). Invokes :meth:`Page.get_pixmap`.
+
+      All parameters except ``pno`` are *keyword-only.*
 
       :arg int pno: page number, 0-based in ``-∞ < pno < page_count``.
 

--- a/fitz/utils.py
+++ b/fitz/utils.py
@@ -809,7 +809,16 @@ def get_page_text(
     return doc[pno].get_text(option, clip=clip, flags=flags, sort=sort)
 
 
-def get_pixmap(page: Page, *args, **kw) -> Pixmap:
+def get_pixmap(
+        page: Page,
+        *,
+        matrix: matrix_like=Identity,
+        dpi=None,
+        colorspace: Colorspace=csRGB,
+        clip: rect_like=None,
+        alpha: bool=False,
+        annots: bool=True,
+        ) -> Pixmap:
     """Create pixmap of page.
 
     Keyword args:
@@ -820,18 +829,10 @@ def get_pixmap(page: Page, *args, **kw) -> Pixmap:
         alpha: (bool) whether to include alpha channel
         annots: (bool) whether to also render annotations
     """
-    if args:
-        raise ValueError("method accepts keywords only")
     CheckParent(page)
-    matrix = kw.get("matrix", Identity)
-    dpi = kw.get("dpi", None)
     if dpi:
         zoom = dpi / 72
         matrix = Matrix(zoom, zoom)
-    colorspace = kw.get("colorspace", csRGB)
-    clip = kw.get("clip")
-    alpha = bool(kw.get("alpha", False))
-    annots = bool(kw.get("annots", True))
 
     if type(colorspace) is str:
         if colorspace.upper() == "GRAY":
@@ -854,7 +855,9 @@ def get_pixmap(page: Page, *args, **kw) -> Pixmap:
 def get_page_pixmap(
     doc: Document,
     pno: int,
+    *,
     matrix: matrix_like = Identity,
+    dpi=None,
     colorspace: Colorspace = csRGB,
     clip: rect_like = None,
     alpha: bool = False,
@@ -873,7 +876,7 @@ def get_page_pixmap(
         annots: (bool) also render annotations
     """
     return doc[pno].get_pixmap(
-        matrix=matrix, colorspace=colorspace, clip=clip, alpha=alpha, annots=annots
+        matrix=matrix, dpi=dpi, colorspace=colorspace, clip=clip, alpha=alpha, annots=annots
     )
 
 


### PR DESCRIPTION
…quire keyword-only args.

In `get_pixmap()`, use Python's special `*` arg to force args to be keyword-only instead of enforcing this in the code.

In `get_page_pixmap()`, also use Python's special `*` arg to force args to be keyword-only. This makes the fn conform to the documentation in docs/document.rst, but could break code that used to use non-keyword args.