### PR TITLE
Fixes many links to the PyMuPDF-Utilities repo scripts.

### DIFF
--- a/docs/document.rst
+++ b/docs/document.rst
@@ -1242,7 +1242,7 @@ For details on **embedded files** refer to Appendix 3.
 
        1. If *from_page > to_page*, pages will be **copied in reverse order**. If *0 <= from_page == to_page*, then one page will be copied.
 
-       2. *docsrc* TOC entries **will not be copied**. It is easy however, to recover a table of contents for the resulting document. Look at the examples below and at program `PDFjoiner.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/PDFjoiner.py>`_ in the *examples* directory: it can join PDF documents and at the same time piece together respective parts of the tables of contents.
+       2. *docsrc* TOC entries **will not be copied**. It is easy however, to recover a table of contents for the resulting document. Look at the examples below and at program `join.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/join-documents/join.py>`_ in the *examples* directory: it can join PDF documents and at the same time piece together respective parts of the tables of contents.
 
 
     .. index::
@@ -1625,7 +1625,7 @@ For details on **embedded files** refer to Appendix 3.
           * Both xref numbers must represent existing dictionaries.
           * Before data is copied from *source*, all *target* dictionary keys are deleted. You can specify exceptions from this in the *keep* list. If *source* however has a same-named key, its value will still replace the target.
           * If *source* is a :data:`stream` object, then these data will also be copied over, and *target* will be converted to a stream object.
-          * A typical use case is to replace or remove an existing image without using redaction annotations. Example scripts can be seen `here <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/image-replacement>`_.
+          * A typical use case is to replace or remove an existing image without using redaction annotations. Example scripts can be seen `here <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/replace-image>`_.
 
    .. method:: Document.extract_image(xref)
 
@@ -1977,7 +1977,7 @@ Clear metadata information. If you do this out of privacy / data protection conc
 
 :meth:`set_toc` Demonstration
 ----------------------------------
-This shows how to modify or add a table of contents. Also have a look at `csv2toc.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/csv2toc.py>`_ and `toc2csv.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/toc2csv.py>`_ in the examples directory.
+This shows how to modify or add a table of contents. Also have a look at `import.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/import-toc/import.py>`_ and `export.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/export-toc/export.py>`_ in the examples directory.
 
 >>> import fitz
 >>> doc = fitz.open("test.pdf")
@@ -2010,7 +2010,7 @@ This shows how to modify or add a table of contents. Also have a look at `csv2to
         t[2] += pages1                     # by old len(doc1)
 >>> doc1.set_toc(toc1 + toc2)               # now result has total TOC
 
-Obviously, similar ways can be found in more general situations. Just make sure that hierarchy levels in a row do not increase by more than one. Inserting dummy bookmarks before and after *toc2* segments would heal such cases. A ready-to-use GUI (wxPython) solution can be found in script `PDFjoiner.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/PDFjoiner.py>`_ of the examples directory.
+Obviously, similar ways can be found in more general situations. Just make sure that hierarchy levels in a row do not increase by more than one. Inserting dummy bookmarks before and after *toc2* segments would heal such cases. A ready-to-use GUI (wxPython) solution can be found in script `join.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/join-documents/join.py>`_ of the examples directory.
 
 **(2) More examples:**
 
@@ -2048,7 +2048,7 @@ Other Examples
 
 .. [#f1] Content streams describe what (e.g. text or images) appears where and how on a page. PDF uses a specialized mini language similar to PostScript to do this (pp. 643 in :ref:`AdobeManual`), which gets interpreted when a page is loaded.
 
-.. [#f2] However, you **can** use :meth:`Document.get_toc` and :meth:`Page.get_links` (which are available for all document types) and copy this information over to the output PDF. See demo `pdf-converter.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/pdf-converter.py>`_.
+.. [#f2] However, you **can** use :meth:`Document.get_toc` and :meth:`Page.get_links` (which are available for all document types) and copy this information over to the output PDF. See demo `convert.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/convert-document/convert.py>`_.
 
 .. [#f3] For applicable (EPUB) document types, loading a page via its absolute number may result in layouting a large part of the document, before the page can be accessed. To avoid this performance impact, prefer chapter-based access. Use convenience methods and attributes :meth:`Document.next_location`, :meth:`Document.prev_location` and :attr:`Document.last_location` for maintaining a high level of coding efficiency.
 

--- a/docs/module.rst
+++ b/docs/module.rst
@@ -119,7 +119,7 @@ Extract fonts or images from selected PDF pages to a desired directory::
 
 The output directory must already exist.
 
-.. note:: Except for output directory creation, this feature is **functionally equivalent** to and obsoletes `this script <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/extract-imga.py>`_.
+.. note:: Except for output directory creation, this feature is **functionally equivalent** to and obsoletes `this script <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/extract-images/extract-from-pages.py>`_.
 
 
 Joining PDF Documents

--- a/docs/page.rst
+++ b/docs/page.rst
@@ -1481,7 +1481,7 @@ In a nutshell, this is what you can do with PyMuPDF:
       PDF only: Display a page of another PDF as a **vector image** (otherwise similar to :meth:`Page.insert_image`). This is a multi-purpose method. For example, you can use it to
 
       * create "n-up" versions of existing PDF files, combining several input pages into **one output page** (see example `4-up.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/4-up.py>`_),
-      * create "posterized" PDF files, i.e. every input page is split up in parts which each create a separate output page (see `posterize.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/posterize.py>`_),
+      * create "posterized" PDF files, i.e. every input page is split up in parts which each create a separate output page (see `posterize.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/posterize-document/posterize.py>`_),
       * include PDF-based vector images like company logos, watermarks, etc., see `svg-logo.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/svg-logo.py>`_, which puts an SVG-based logo on each page (requires additional packages to deal with SVG-to-PDF conversions).
 
       :arg rect_like rect: where to place the image on current page. Must be finite and its intersection with the page must not be empty.

--- a/docs/recipes-general.rst
+++ b/docs/recipes-general.rst
@@ -38,7 +38,7 @@ PDF supports incorporating arbitrary data. This can be done in one of two ways: 
 
 The basic differences between these options are **(1)** you need edit permission to embed a file, but only annotation permission to attach, **(2)** like all annotations, attachments are visible on a page, embedded files are not.
 
-There exist several example scripts: `embedded-list.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-list.py>`_, `new-annots.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/new-annots.py>`_.
+There exist several example scripts: `list.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/list-embedded/list.py>`_, `new-annots.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/new-annots.py>`_.
 
 Also look at the sections above and at chapter :ref:`Appendix 3`.
 
@@ -100,7 +100,7 @@ How to Join :title:`PDFs`
 
 It is easy to join PDFs with method :meth:`Document.insert_pdf`. Given open :title:`PDF` documents, you can copy page ranges from one to the other. You can select the point where the copied pages should be placed, you can revert the page sequence and also change page rotation. This Wiki `article <https://github.com/pymupdf/PyMuPDF/wiki/Inserting-Pages-from-other-PDFs>`_ contains a full description.
 
-The GUI script `PDFjoiner.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/PDFjoiner.py>`_ uses this method to join a list of files while also joining the respective table of contents segments. It looks like this:
+The GUI script `join.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/join-documents/join.py>`_ uses this method to join a list of files while also joining the respective table of contents segments. It looks like this:
 
 .. image:: images/img-pdfjoiner.*
    :scale: 60

--- a/docs/recipes-text.rst
+++ b/docs/recipes-text.rst
@@ -96,7 +96,7 @@ If you see a table in a document, you are not normally looking at something like
 
 Extracting a tabular data from such a page area therefore means that you must find a way to **(1)** graphically indicate table and column borders, and **(2)** then extract text based on this information.
 
-The wxPython GUI script `wxTableExtract.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/wxTableExtract.py>`_ strives to exactly do that. You may want to have a look at it and adjust it to your liking.
+The wxPython GUI script `extract.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/extract-table/extract.py>`_ strives to exactly do that. You may want to have a look at it and adjust it to your liking.
 
 ----------
 

--- a/docs/shape.rst
+++ b/docs/shape.rst
@@ -100,7 +100,7 @@ Several draw methods can be executed in a row and each one of them will contribu
 
       .. image:: images/img-squiggly.*
 
-      .. note:: Waves drawn are **not** trigonometric (sine / cosine). If you need that, have a look at `draw-sines.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/draw-sines.py>`_.
+      .. note:: Waves drawn are **not** trigonometric (sine / cosine). If you need that, have a look at `draw.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/draw-sines/draw.py>`_.
 
    .. index::
       pair: breadth; draw_zigzag

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -419,26 +419,26 @@ This document also contains a :ref:`FAQ`. This chapter has close connection to t
 
 
 .. _lxml: https://pypi.org/project/lxml/
-.. _metadata import (PDF only): https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/csv2meta.py
-.. _metadata export: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/meta2csv.py
-.. _toc import (PDF only): https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/csv2toc.py
-.. _toc export: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/toc2csv.py
+.. _metadata import (PDF only): https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/import-metadata/import.py
+.. _metadata export: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/export-metadata/export.py
+.. _toc import (PDF only): https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/import-toc/import.py
+.. _toc export: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/export-toc/export.py
 .. _Vector Image Support page: https://github.com/pymupdf/PyMuPDF/wiki/Vector-Image-Support
 .. _examples: https://github.com/pymupdf/PyMuPDF/tree/master/examples
 .. _Pillow documentation: https://Pillow.readthedocs.io
-.. _here it is!: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/doc-browser.py
+.. _here it is!: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/browse-document/browse.py
 .. _PySimpleGUI: https://pypi.org/project/PySimpleGUI/
 .. _demo.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/demo.py
 .. _demo-lowlevel.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/demo-lowlevel.py
 .. _"MuPDF Explored": https://mupdf.com/docs/mupdf-explored.html
 .. _Artifex: https://www.artifex.com
-.. _pdf-converter.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/pdf-converter.py
-.. _PDFjoiner.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/PDFjoiner.py
+.. _pdf-converter.py: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/convert-document/convert.py
+.. _PDFjoiner.py: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/join-documents/join.py
 .. _dealing with embedding files: https://github.com/pymupdf/PyMuPDF/wiki/Dealing-with-Embedded-Files
-.. _embedded-copy.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-copy.py
-.. _embedded-export.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-export.py
-.. _embedded-import.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-import.py
-.. _embedded-list.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/embedded-list.py
+.. _embedded-copy.py: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/copy-embedded/copy.py
+.. _embedded-export.py: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/export-embedded/export.py
+.. _embedded-import.py: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/import-embedded/import.py
+.. _embedded-list.py: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/list-embedded/list.py
 .. _Wiki: https://github.com/pymupdf/PyMuPDF/wiki
 
 

--- a/docs/znames.rst
+++ b/docs/znames.rst
@@ -36,7 +36,7 @@ Starting immediately, all deprecated objects (methods and properties) will show 
             A Page object.
         
 
-There is a utility script `alias-changer.py <https://github.com/pymupdf/PyMuPDF-Utilities/alias-changer.py>`_ which can be used to do mass-renames in your scripts. It accepts either a single file or a folder as argument. If a folder is supplied, all its Python files and those of its subfolders are changed. Optionally, backups of the scripts can be taken.
+There is a utility script `alias-changer.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/alias-changer.py>`_ which can be used to do mass-renames in your scripts. It accepts either a single file or a folder as argument. If a folder is supplied, all its Python files and those of its subfolders are changed. Optionally, backups of the scripts can be taken.
 
 Deprecated names are not separately documented. The following list will help you find the documentation of the original.
 


### PR DESCRIPTION
- A recent reorganization & naming of these scripts on `PyMuPDF-Utilities` caused the links on the documentation here to
break.