### PR TITLE
Fixing #2300

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -1863,29 +1863,6 @@ struct Document
             else Py_RETURN_FALSE;
         }
 
-        #if FZ_VERSION_MAJOR == 1 && FZ_VERSION_MINOR <= 21
-        /* The underlying struct members that these methods give access to, are
-        not in mupdf-1.22. */
-        CLOSECHECK0(has_xref_streams, """Check if xref table is a stream.""")
-        %pythoncode%{@property%}
-        PyObject *has_xref_streams()
-        {
-            pdf_document *pdf = pdf_specifics(gctx, (fz_document *) $self);
-            if (!pdf) Py_RETURN_FALSE;
-            if (pdf->has_xref_streams) Py_RETURN_TRUE;
-            Py_RETURN_FALSE;
-        }
-
-        CLOSECHECK0(has_old_style_xrefs, """Check if xref table is old style.""")
-        %pythoncode%{@property%}
-        PyObject *has_old_style_xrefs()
-        {
-            pdf_document *pdf = pdf_specifics(gctx, (fz_document *) $self);
-            if (!pdf) Py_RETURN_FALSE;
-            if (pdf->has_old_style_xrefs) Py_RETURN_TRUE;
-            Py_RETURN_FALSE;
-        }
-        #endif
 
         CLOSECHECK0(is_dirty, """True if PDF has unsaved changes.""")
         %pythoncode%{@property%}

--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -4854,10 +4854,27 @@ struct Page {
         //----------------------------------------------------------------
         // bound()
         //----------------------------------------------------------------
+        FITZEXCEPTION(bound, !result)
         PARENTCHECK(bound, """Get page rectangle.""")
-        %pythonappend bound %{val = Rect(val)%}
+        %pythonappend bound %{
+        val = Rect(val)
+        if val.is_infinite and self.parent.is_pdf:
+            cb = self.cropbox
+            w, h = cb.width, cb.height
+            if self.rotation not in (0, 180):
+                w, h = h, w
+            val = Rect(0, 0, w, h)
+            msg = TOOLS.mupdf_warnings(reset=False).splitlines()[-1]
+            print(msg, file=sys.stderr)
+        %}
         PyObject *bound() {
-            fz_rect rect = fz_bound_page(gctx, (fz_page *) $self);
+            fz_rect rect = fz_infinite_rect;
+            fz_try(gctx) {
+                rect = fz_bound_page(gctx, (fz_page *) $self);
+            }
+            fz_catch(gctx) {
+                ;
+            }
             return JM_py_from_rect(rect);
         }
         %pythoncode %{rect = property(bound, doc="page rectangle")%}

--- a/fitz/version.i
+++ b/fitz/version.i
@@ -1,6 +1,6 @@
 %pythoncode %{
-VersionFitz = "1.21.1" # MuPDF version.
-VersionBind = "1.21.1" # PyMuPDF version.
-VersionDate = "2022-12-13 00:00:01"
-version = (VersionBind, VersionFitz, "20221213000001")
+VersionFitz = "1.22.0" # MuPDF version.
+VersionBind = "1.22.0" # PyMuPDF version.
+VersionDate = "2023-02-07 00:00:01"
+version = (VersionBind, VersionFitz, "20230207000001")
 %}


### PR DESCRIPTION
Page method `bound()` wraps MuPDF function fz_bound_page, but did not catch possible exceptions raised by this function. In these (rare) cases the Python interpreter will end. We now wrap the function with try / catch but do not raise an exception - instead the MuPDF error message is displayed to sys.stderr. For non-PDF documents the infinite rectangle is returned, for PDFs the page rectangle is instead derived from the CropBox as fallback.