### PR TITLE
Rename "quality" parameter for saving a Pixmap in JPG format

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -8236,7 +8236,7 @@ Args:
         }
 
         %pythoncode %{
-def tobytes(self, output="png", quality=95):
+def tobytes(self, output="png", jpg_quality=95):
     """Convert to binary image stream of desired type.
 
     Can be used as input to GUI packages like tkinter.
@@ -8366,7 +8366,7 @@ def tobytes(self, output="png", quality=95):
             Py_RETURN_NONE;
         }
         %pythoncode %{
-def save(self, filename, output=None, quality=95):
+def save(self, filename, output=None, jpg_quality=95):
     """Output as image in format determined by filename extension.
 
     Args:


### PR DESCRIPTION
The new Pixmap output format JPG supports a quality parameter. For clarity reasons we choose the name "jpg_quality".