### PR TITLE
Documentation: Fixes copyright printing from data provided in conf.py.

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -118,13 +118,18 @@ button.cta a {
 
 
 /*** Furo theme overrides ***/
-
+/* This is to do with hiding the Furo link text and the "Made with" text */
 .bottom-of-page .left-details {
-    display: none;
+    font-size:0;
 }
 
-.bottom-of-page .right-details:after {
-    content: "© Copyright 2023, Artifex";
+.bottom-of-page .left-details a {
+    display:none;
+}
+
+/* Now ensure that the other copyright text is visible here */
+.bottom-of-page .left-details > * {
+    font-size:12px;
 }
 
 .sidebar-brand-text {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 import re
 import sys
 import os
+import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -37,7 +38,8 @@ root_doc = "index"
 
 # General information about the project.
 project = "PyMuPDF"
-copyright = "2015-2023, Artifex"
+thisday = datetime.date.today()
+copyright = "2015-" + str(thisday.year) + ", Artifex"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This fix was just applied to mupdf documentation. The Furo theme was hiding the actual copyright info from the `conf.py` because it inserted advertising for the Furo theme in the footer. But the side-effect was that we lost copyright information from the `conf.py` in favour of a hardcoded CSS string.

This re-instates the copyright being sourced from `conf.py` whilst hiding the Furo advertisement.

Nothing against Furo - just don't want it hyperlinking at the bottom of every page!
