### PR TITLE
Fix #2501: Adjust documentation to actual function behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ On **[PyPI](https://pypi.org/project/PyMuPDF)** since August 2016: [![Downloads]
 
 PyMuPDF adds Python bindings and abstractions to [MuPDF](https://mupdf.com/), a lightweight PDF, XPS, and eBook viewer, renderer, and toolkit. Both PyMuPDF and MuPDF are maintained and developed by Artifex Software, Inc.
 
-MuPDF can access files in PDF, XPS, OpenXPS, CBZ, EPUB and FB2 (eBooks) formats, and it is known for its top performance and exceptional rendering quality.
+MuPDF can access files in PDF, XPS, OpenXPS, CBZ, EPUB, MOBI and FB2 (eBooks) formats, and it is known for its top performance and exceptional rendering quality.
 
-With PyMuPDF you can access files with extensions like `.pdf`, `.xps`, `.oxps`, `.cbz`, `.fb2` or `.epub`. In addition, about 10 popular image formats can also be handled like documents: `.png`, `.jpg`, `.bmp`, `.tiff`, etc.
+With PyMuPDF you can access files with extensions like `.pdf`, `.xps`, `.oxps`, `.cbz`, `.fb2`, `.mobi` or `.epub`. In addition, about 10 popular image formats can also be handled like documents: `.png`, `.jpg`, `.bmp`, `.tiff`, `.svg` etc.
 
 # Usage
 For all supported document types (i.e. **_including images_**) you can

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -393,14 +393,15 @@ Yet others are handy, general-purpose utilities.
 
       * New in v1.16.7
       * Changed in v1.19.5: also return natural image orientation extracted from EXIF data if present.
+      * Changed in v1.22.5: always return `None` in error cases instead of an empty dictionary.
 
       Show important properties of an image provided as a memory area. Its main purpose is to avoid using other Python packages just to determine them.
 
-      :arg bytes|bytearray|BytesIO|file stream: an image either in memory or an **opened** file. A memory resident image maybe any of the formats *bytes*, *bytearray* or *io.BytesIO*.
+      :arg bytes|bytearray|BytesIO|file stream: either an image in memory or an **opened** file. An image in memory may be any of the formats `bytes`, `bytearray` or `io.BytesIO`.
 
       :rtype: dict
       :returns:
-         No exception is ever raised: in case of error, the empty dictionary `{}` is returned. Otherwise, there are the following items::
+         No exception is ever raised. In case of an error, `None` is returned. Otherwise, there are the following items::
 
             In [2]: fitz.image_profile(open("nur-ruhig.jpg", "rb").read())
             Out[2]:
@@ -415,7 +416,7 @@ Yet others are handy, general-purpose utilities.
             'ext': 'jpeg',
             'cs-name': 'DeviceRGB'}
 
-         There is the following relation to *Exif* information encoded in `orientation`, and correspondingly in the `transform` matrix-like (quoted from MuPDF documentation, *ccw* = counter-clockwise):
+         There is the following relation to **Exif** information encoded in `orientation`, and correspondingly in the `transform` matrix-like (quoted from MuPDF documentation, *ccw* = counter-clockwise):
 
             0. Undefined
             1. 0 degree ccw rotation. (Exif = 1)
@@ -430,7 +431,7 @@ Yet others are handy, general-purpose utilities.
 
          .. note::
 
-            * For some "exotic" images (FAX encodings, RAW formats and the like), this method will not work and return *None*. You can however still work with such images in PyMuPDF, e.g. by using :meth:`Document.extract_image` or create pixmaps via `Pixmap(doc, xref)`. These methods will automatically convert exotic images to the PNG format before returning results.
+            * For some "exotic" images (FAX encodings, RAW formats and the like), this method will not work. You can however still work with such images in PyMuPDF, e.g. by using :meth:`Document.extract_image` or create pixmaps via `Pixmap(doc, xref)`. These methods will automatically convert exotic images to the PNG format before returning results.
             * You can also get the properties of images embedded in a PDF, via their :data:`xref`. In this case make sure to extract the raw stream: `fitz.image_profile(doc.xref_stream_raw(xref))`.
             * Images as returned by the image blocks of :meth:`Page.get_text` using "dict" or "rawdict" options are also supported.
 


### PR DESCRIPTION
The function `image_profile` returns `None` in all irregular situations - never the empty dictionary.

Add MOBI as supported file format on the home page description.