### PR TITLE
Update fill_textbox to better respect rect.width

### DIFF
--- a/fitz/utils.py
+++ b/fitz/utils.py
@@ -4356,10 +4356,10 @@ def fill_textbox(
             while n > 0:
                 wl = sum(wl_lst[:n])
                 if wl <= width:
-                    nwords.append(w[: n + 1])
+                    nwords.append(w[:n])
                     word_lengths.append(wl)
-                    w = w[n + 1 :]
-                    wl_lst = wl_lst[n + 1 :]
+                    w = w[n:]
+                    wl_lst = wl_lst[n:]
                     n = len(wl_lst)
                 else:
                     n -= 1


### PR DESCRIPTION
The function norm_words() in fill_textbox() had a bug in its last loop, appending n+1 characters when actually measuring width of n characters. 

It led to a bug in fill_texbox when you tried to write a **single word mostly composed of "wide" letters (M,m, W, w...)**, causing the written text to exceed the given rect.

The fix was just to replace n+1 by n.

Original Bug
![Original_Bug](https://github.com/pymupdf/PyMuPDF/assets/57907121/41c8e7d9-272b-4d78-96e4-6a71213d8ddd)
Fixed version
![Fixed_fill_textbox](https://github.com/pymupdf/PyMuPDF/assets/57907121/821e9d75-062e-4038-acae-f41168ca4040)


Here is a PDF file and a short notebook to search and replace single words or short expression to show the bug and test the fix.
[testpdf.pdf](https://github.com/pymupdf/PyMuPDF/files/11968371/testpdf.pdf)
```
import fitz

filepath = 'testpdf.pdf'
debug = True
target = 'Broadcast'
replacement = 'MMMMMMM'
savefile = 'testpdf-modified.pdf'

doc = fitz.Document(filepath)
page = doc.load_page(0)
hits = page.search_for(target, flags=0)

for rect in hits:
	mydict = page.get_text('dict', clip=rect, flags=fitz.TEXTFLAGS_DICT & ~fitz.TEXT_PRESERVE_IMAGES, sort=True)

	fontname = mydict['blocks'][0]['lines'][0]['spans'][0]['font']
	fontsize = mydict['blocks'][0]['lines'][0]['spans'][0]['size']

	textwriter = fitz.TextWriter(page.rect)
		
	annot = page.add_redact_annot(rect)
	page.apply_redactions(fitz.PDF_REDACT_IMAGE_NONE)

	rect.y0,rect.y1 = rect.y0 - (fontsize/5), rect.y1 - (fontsize/5)	# Pull up the rectangle a bit to align pos with suppressed characters

	page.add_rect_annot(annot.rect)

	rc = [("Non empty", "0")]
	while rc != []:
		try:
			rc = textwriter.fill_textbox(rect, text=replacement, pos=(rect.bl.x, rect.bl.y-0.1), font=fitz.Font(fontname), fontsize=fontsize, warn=False, align=fitz.TEXT_ALIGN_JUSTIFY, small_caps=False)
		except Exception as err:
			fontsize -= 0.1
	textwriter.write_text(page)

doc.save(savefile, garbage=3, deflate=True)
```