### PR TITLE
Fixing typos in documentation and missing parameters description

### DIFF
--- a/docs/page.rst
+++ b/docs/page.rst
@@ -1086,7 +1086,7 @@ In a nutshell, this is what you can do with PyMuPDF:
 
       Create a :ref:`TextPage` for the page.
 
-      :arg in flags: indicator bits controlling the content available for subsequent text extractions and searches -- see the parameter of :meth:`Page.get_text`.
+      :arg int flags: indicator bits controlling the content available for subsequent text extractions and searches -- see the parameter of :meth:`Page.get_text`.
 
       :arg rect-like clip: *(new in v1.17.7)* restrict extracted text to this area.
 

--- a/docs/page.rst
+++ b/docs/page.rst
@@ -1107,7 +1107,7 @@ In a nutshell, this is what you can do with PyMuPDF:
 
       Create a :ref:`TextPage` for the page that includes OCRed text. MuPDF will invoke Tesseract-OCR if this method is used. Otherwise this is a normal :ref:`TextPage` object.
 
-      :arg in flags: indicator bits controlling the content available for subsequent test extractions and searches -- see the parameter of :meth:`Page.get_text`.
+      :arg int flags: indicator bits controlling the content available for subsequent test extractions and searches -- see the parameter of :meth:`Page.get_text`.
       :arg str language: the expected language(s). Use "+"-separated values if multiple languages are expected, "eng+spa" for English and Spanish.
       :arg int dpi: the desired resolution in dots per inch. Influences recognition quality (and execution time).
       :arg bool full: whether to OCR the full page, or just the displayed images.

--- a/docs/textpage.rst
+++ b/docs/textpage.rst
@@ -33,11 +33,13 @@ For a description of what this class is all about, see Appendix 2.
 
 .. class:: TextPage
 
-   .. method:: extractText
+   .. method:: extractText(sort=False)
 
-   .. method:: extractTEXT
+   .. method:: extractTEXT(sort=False)
 
       Return a string of the page's complete text. The text is UTF-8 unicode and in the same sequence as specified at the time of document creation.
+
+      :arg bool sort: (new in v1.19.1) sort the output by vertical, then horizontal coordinates. In many cases, this should suffice to generate a "natural" reading order.
 
       :rtype: str
 
@@ -72,15 +74,19 @@ For a description of what this class is all about, see Appendix 2.
 
       :rtype: str
 
-   .. method:: extractDICT
+   .. method:: extractDICT(sort=False)
 
       Textpage content as a Python dictionary. Provides same information detail as HTML. See below for the structure.
 
+      :arg bool sort: (new in v1.19.1) sort the output by vertical, then horizontal coordinates. In many cases, this should suffice to generate a "natural" reading order.
+
       :rtype: dict
 
-   .. method:: extractJSON
+   .. method:: extractJSON(sort=False)
 
       Textpage content as a JSON string. Created by `json.dumps(TextPage.extractDICT())`. It is included for backlevel compatibility. You will probably use this method ever only for outputting the result to some file. The  method detects binary image data and converts them to base64 encoded strings.
+
+      :arg bool sort: (new in v1.19.1) sort the output by vertical, then horizontal coordinates. In many cases, this should suffice to generate a "natural" reading order.
 
       :rtype: str
 
@@ -96,15 +102,19 @@ For a description of what this class is all about, see Appendix 2.
 
       :rtype: str
 
-   .. method:: extractRAWDICT
+   .. method:: extractRAWDICT(sort=False)
 
       Textpage content as a Python dictionary -- technically similar to :meth:`extractDICT`, and it contains that information as a subset (including any images). It provides additional detail down to each character, which makes using XML obsolete in many cases. See below for the structure.
 
+      :arg bool sort: (new in v1.19.1) sort the output by vertical, then horizontal coordinates. In many cases, this should suffice to generate a "natural" reading order.
+
       :rtype: dict
 
-   .. method:: extractRAWJSON
+   .. method:: extractRAWJSON(sort=False)
 
       Textpage content as a JSON string. Created by `json.dumps(TextPage.extractRAWDICT())`. You will probably use this method ever only for outputting the result to some file. The  method detects binary image data and converts them to base64 encoded strings.
+
+      :arg bool sort: (new in v1.19.1) sort the output by vertical, then horizontal coordinates. In many cases, this should suffice to generate a "natural" reading order.
 
       :rtype: str
 


### PR DESCRIPTION
I fixed two small typos in Page documentation ("flags (in)" -> "flags (int)").
While browsing the package code i found that some functions to extract text from a TextPage allowed the use of a sort parameter that wasn't specified in the documentation, so i added it to the functions definitions and their description. I used the description on the sort parameter description from Page.get_text().

I also found an error that i can't fix via pull request: The [documentation for TextPage](https://pymupdf.readthedocs.io/en/latest/textpage.html) specify that we can use TextPage.extractText() or  TextPage.extractTEXT(), but only one of those functions exist in the package (TextPage.extractText()).
The easiest fix would be to add TextPage.extractTEXT() in the code on your side, as a copy of the existing function.
If not, i could just erase TextPage.extractTEXT() from the documentation in this pull request.
