### PR TITLE
Support pixmap "unmultiply"

### DIFF
--- a/docs/annot.rst
+++ b/docs/annot.rst
@@ -83,7 +83,11 @@ There is a parent-child relationship between an annotation and its page. If the 
 
       :rtype: :ref:`Pixmap`
 
-      .. note:: If the annotation has just been created or modified, you should reload the page first via *page = doc.reload_page(page)*.
+      .. note::
+         
+         * If the annotation has just been created or modified, you should :meth:`Document.reload_page` the page first via `page = doc.reload_page(page)`.
+
+         * The pixmap will have *"premultiplied"* pixels if `alpha=True`. To learn about some background, e.g. look for "Premultiplied alpha" `here <https://en.wikipedia.org/wiki/Glossary_of_computer_graphics#P>`_.
 
 
    .. index::

--- a/docs/page.rst
+++ b/docs/page.rst
@@ -1479,7 +1479,10 @@ In a nutshell, this is what you can do with PyMuPDF:
      :returns: Pixmap of the page. For fine-controlling the generated image, the by far most important parameter is **matrix**. E.g. you can increase or decrease the image resolution by using **Matrix(xzoom, yzoom)**. If zoom > 1, you will get a higher resolution: zoom=2 will double the number of pixels in that direction and thus generate a 2 times larger image. Non-positive values will flip horizontally, resp. vertically. Similarly, matrices also let you rotate or shear, and you can combine effects via e.g. matrix multiplication. See the :ref:`Matrix` section to learn more.
 
      .. note::
-         The method will respect any page rotation and will not exceed the intersection of `clip` and :attr:`Page.cropbox`. If you need the page's mediabox (and if this is a different rectangle), you can use a snippet like the following to achieve this::
+
+         * The pixmap will have *"premultiplied"* pixels if `alpha=True`. To learn about some background, e.g. look for "Premultiplied alpha" `here <https://en.wikipedia.org/wiki/Glossary_of_computer_graphics#P>`_.
+
+         * The method will respect any page rotation and will not exceed the intersection of `clip` and :attr:`Page.cropbox`. If you need the page's mediabox (and if this is a different rectangle), you can use a snippet like the following to achieve this::
 
             In [1]: import fitz
             In [2]: doc=fitz.open("demo1.pdf")

--- a/docs/pixmap.rst
+++ b/docs/pixmap.rst
@@ -388,7 +388,7 @@ Have a look at the :ref:`FAQ` section to see some pixmap usage "at work".
                doc.save("ocr-images.pdf")
 
 
-   ..  method:: pil_save(*args, **kwargs)
+   ..  method:: pil_save(*args, unmultiply=False, **kwargs)
 
       * New in v1.17.3
 
@@ -398,19 +398,24 @@ Have a look at the :ref:`FAQ` section to see some pixmap usage "at work".
       * Storing EXIF information.
       * If you do not provide dpi information, the values *xres*, *yres* stored with the pixmap are automatically used.
 
-      A simple example: `pix.pil_save("some.webp", optimize=True, dpi=(150, 150))`. For details on other parameters see the Pillow documentation.
+      A simple example: `pix.pil_save("some.webp", optimize=True, dpi=(150, 150))`.
+      
+      :arg bool unmultiply: If the pixmap's colorspace is RGB with transparency, the alpha values may or may not already be multiplied into the color components ref/green/blue (called "premultiplied"). To enforce undoing premultiplication, set this parameter to `True`. To learn about some background, e.g. look for "Premultiplied alpha" `here <https://en.wikipedia.org/wiki/Glossary_of_computer_graphics#P>`_.
 
-      Since v1.22.0, PyMuPDF supports JPEG output directly. For both, performance reasons and for reducing external dependencies, the use of this method is no longer recommended when outputting JPEG images.
+
+      For details on other parameters see the Pillow documentation.
+
+      Since v1.22.0, PyMuPDF supports JPEG output directly. We recommended to no longer use this method for JPEG output -- for performance reasons and for avoiding unnecessary external dependencies.
 
       :raises ImportError: if Pillow is not installed.
 
-   ..  method:: pil_tobytes(*args, **kwargs)
+   ..  method:: pil_tobytes(*args, unmultiply=False, **kwargs)
 
       * New in v1.17.3
 
-      Return an image as a bytes object in the specified format using Pillow. For example `stream = pix.pil_tobytes(format="WEBP", optimize=True)`. Also see above. For details on other parameters see the Pillow documentation.
+      Return an image as a bytes object in the specified format using Pillow. For example `stream = pix.pil_tobytes(format="WEBP", optimize=True, dpi=(150, 150))`. Also see above. For details on other parameters see the Pillow documentation.
       
-      .raises ImportError: if Pillow is not installed.
+      :raises ImportError: if Pillow is not installed.
 
       :rtype: bytes
 


### PR DESCRIPTION
For Pillow output of RGB images with transparency, the new parameter `unmultiply=True` causes the use of Pillow mode "RGBa" (instead of "RGBA"). The Pillow image will then be created with unmultiplied pixels.

This is the documentary aspect of support closed issue #2593.