### PR TITLE
Fix 2637

### DIFF
--- a/fitz/helper-devices.i
+++ b/fitz/helper-devices.i
@@ -307,7 +307,7 @@ jm_lineart_path(fz_context *ctx, jm_lineart_device *dev, const fz_path *path)
 	DICT_SETITEM_DROP(dev_pathdict, dictkey_items, PyList_New(0));
 	fz_walk_path(ctx, path, &trace_path_walker, dev);
 	// Check if any items were added ...
-	if (!PyList_Size(PyDict_GetItem(dev_pathdict, dictkey_items))) {
+	if (!PyDict_GetItem(dev_pathdict, dictkey_items) || !PyList_Size(PyDict_GetItem(dev_pathdict, dictkey_items))) {
 		Py_CLEAR(dev_pathdict);
 	}
 }
@@ -468,6 +468,9 @@ jm_lineart_clip_path(fz_context *ctx, fz_device *dev_, const fz_path *path, int 
 	trace_device_ctm = ctm; //fz_concat(ctm, trace_device_ptm);
 	path_type = CLIP_PATH;
 	jm_lineart_path(ctx, dev, path);
+	if (!dev_pathdict) {
+		return;
+	}
 	DICT_SETITEM_DROP(dev_pathdict, dictkey_type, PyUnicode_FromString("clip"));
 	DICT_SETITEMSTR_DROP(dev_pathdict, "even_odd", JM_BOOL(even_odd));
 	if (!PyDict_GetItemString(dev_pathdict, "closePath")) {
@@ -489,6 +492,9 @@ jm_lineart_clip_stroke_path(fz_context *ctx, fz_device *dev_, const fz_path *pat
 	trace_device_ctm = ctm; //fz_concat(ctm, trace_device_ptm);
 	path_type = CLIP_STROKE_PATH;
 	jm_lineart_path(ctx, dev, path);
+	if (!dev_pathdict) {
+		return;
+	}
 	DICT_SETITEM_DROP(dev_pathdict, dictkey_type, PyUnicode_FromString("clip"));
 	DICT_SETITEMSTR_DROP(dev_pathdict, "even_odd", Py_BuildValue("s", NULL));
 	if (!PyDict_GetItemString(dev_pathdict, "closePath")) {

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -18315,6 +18315,8 @@ def jm_lineart_clip_path(dev, ctx, path, even_odd, ctm, scissor):
    dev.ctm = mupdf.FzMatrix(ctm)    # fz_concat(ctm, trace_device_ptm);
    dev.path_type = trace_device_CLIP_PATH
    jm_lineart_path(dev, ctx, path)
+   if dev.pathdict is None:
+       return
    dev.pathdict[ dictkey_type] = 'clip'
    dev.pathdict[ 'even_odd'] = bool(even_odd)
    if 'closePath' not in dev.pathdict:
@@ -18335,6 +18337,8 @@ def jm_lineart_clip_stroke_path(dev, ctx, path, stroke, ctm, scissor):
    dev.ctm = mupdf.FzMatrix(ctm)    # fz_concat(ctm, trace_device_ptm);
    dev.path_type = trace_device_CLIP_STROKE_PATH
    jm_lineart_path(dev, ctx, path)
+   if dev.pathdict is None:
+       return
    dev.pathdict['dictkey_type'] = 'clip'
    dev.pathdict['even_odd'] = None
    if 'closePath' not in dev.pathdict:

--- a/src/extra.i
+++ b/src/extra.i
@@ -2850,7 +2850,7 @@ jm_lineart_path(jm_lineart_device *dev, const fz_path *path)
     DICT_SETITEM_DROP(dev->pathdict, dictkey_items, PyList_New(0));
     mupdf::ll_fz_walk_path(path, &trace_path_walker, dev);
     // Check if any items were added ...
-    if (!PyList_Size(PyDict_GetItem(dev->pathdict, dictkey_items)))
+    if (!PyDict_GetItem(dev->pathdict, dictkey_items) || !PyList_Size(PyDict_GetItem(dev->pathdict, dictkey_items)))
     {
         Py_CLEAR(dev->pathdict);
     }
@@ -3018,6 +3018,9 @@ jm_lineart_clip_path(fz_context *ctx, fz_device *dev_, const fz_path *path, int 
     dev->ctm = ctm; //fz_concat(ctm, trace_device_ptm);
     dev->path_type = CLIP_PATH;
     jm_lineart_path(dev, path);
+	if (!dev->pathdict) {
+		return;
+	}
     DICT_SETITEM_DROP(dev->pathdict, dictkey_type, PyUnicode_FromString("clip"));
     DICT_SETITEMSTR_DROP(dev->pathdict, "even_odd", JM_BOOL(even_odd));
     if (!PyDict_GetItemString(dev->pathdict, "closePath")) {
@@ -3038,6 +3041,9 @@ jm_lineart_clip_stroke_path(fz_context *ctx, fz_device *dev_, const fz_path *pat
     dev->ctm = ctm; //fz_concat(ctm, trace_device_ptm);
     dev->path_type = CLIP_STROKE_PATH;
     jm_lineart_path(dev, path);
+	if (!dev->pathdict) {
+		return;
+	}
     DICT_SETITEM_DROP(dev->pathdict, dictkey_type, PyUnicode_FromString("clip"));
     DICT_SETITEMSTR_DROP(dev->pathdict, "even_odd", Py_BuildValue("s", NULL));
     if (!PyDict_GetItemString(dev->pathdict, "closePath")) {

--- a/tests/test_drawings.py
+++ b/tests/test_drawings.py
@@ -175,3 +175,16 @@ def test_2462():
     doc = fitz.open(f"{scriptdir}/resources/test-2462.pdf")
     page = doc[0]
     vg = page.get_drawings(extended=True)
+
+def test_2556():
+    """Ensure that incomplete clip paths will be properly ignored."""
+    doc = fitz.open()  # new empty PDF
+    page = doc.new_page()  # new page
+    # following contains an incomplete clip
+    c = b"q 50 697.6 400 100.0 re W n q 0 0 m W n Q "
+    xref = doc.get_new_xref()  # prepare /Contents object for page
+    doc.update_object(xref,"<<>>")  # new xref now is a dictionary
+    doc.update_stream(xref, c)  # store drawing commands
+    page.set_contents(xref)  # give the page this xref as /Contents
+    # following will bring down interpreter if fix not installed
+    assert page.get_drawings(extended=True)


### PR DESCRIPTION
Fixing #2637:
In Page.insert_textbox, when the last word of a line won't fit in the line buffer, we did not increase the line position. This is now handled correctly.

Other changes:
Support variable setting of character border widths for insert_text() / insert_textbox(). This is a factor to be multiplied with the font size. Default is 0.05 (read: 5% of the fontsize). This value is relevant for text rendering modes 1 and 2 only.

Text extraction mode "words" support a new keyword "delimiters". This is a preparatory change in utils.py and functional only after more changes to come (in `__init__.py`).