### PR TITLE
Flexible word delimiters

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -4030,7 +4030,7 @@ if rbgroups:
         if not type(x) in (list, tuple):
             raise ValueError("bad RBGroup '%s'" % x)
         s = set(x).difference(ocgs)
-        if f != set():
+        if s != set():
             raise ValueError("bad OCGs in RBGroup: %s" % s)
 
 if basestate:
@@ -4625,6 +4625,7 @@ if basestate:
                     old_annots[k] = v
                 page._erase()  # remove the page
                 page = None
+                TOOLS.store_shrink(100)
                 page = self.load_page(pno)  # reload the page
 
                 # copy annot refs over to the new dictionary
@@ -5542,8 +5543,6 @@ struct Page {
                 r = pdf_annot_rect(gctx, annot);
                 r = fz_make_rect(p.x, p.y, p.x + r.x1 - r.x0, p.y + r.y1 - r.y0);
                 pdf_set_annot_rect(gctx, annot, r);
-                int flags = PDF_ANNOT_IS_PRINT;
-                pdf_set_annot_flags(gctx, annot, flags);
 
                 if (icon)
                     pdf_set_annot_icon_name(gctx, annot, icon);
@@ -5554,7 +5553,6 @@ struct Page {
                 pdf_dict_put_text_string(gctx, annot_obj, PDF_NAME(Contents), filename);
                 pdf_update_annot(gctx, annot);
                 pdf_set_annot_rect(gctx, annot, r);
-                pdf_set_annot_flags(gctx, annot, flags);
                 JM_add_annot_id(gctx, annot, "A");
             }
             fz_always(gctx) {
@@ -7616,10 +7614,9 @@ def insert_font(self, fontname="helv", fontfile=None, fontbuffer=None,
                 annot_xrefs = [a[0] for a in self.annot_xrefs() if a[1] not in skip_types]
             else:
                 annot_xrefs = [a[0] for a in self.annot_xrefs() if a[1] in types and a[1] not in skip_types]
+
             for xref in annot_xrefs:
-                annot = self.load_annot(xref)
-                annot._yielded=True
-                yield annot
+                yield self.load_annot(xref)
 
 
         def widgets(self, types=None):
@@ -11533,13 +11530,18 @@ struct TextPage {
         extractIMGINFO(int hashes=0)
         {
             fz_stext_block *block;
-            int block_n = -1;
+            int block_n = -1, leave = 0;
             fz_stext_page *this_tpage = (fz_stext_page *) $self;
             PyObject *rc = NULL, *block_dict = NULL;
             fz_pixmap *pix = NULL;
+            fz_rect bbox;
             fz_try(gctx) {
                 rc = PyList_New(0);
                 for (block = this_tpage->first_block; block; block = block->next) {
+                    bbox = block->bbox;
+                    if (JM_ignore_rect(bbox)) {
+                        continue; // guard against nonsense block bbox
+                    }
                     block_n++;
                     if (block->type == FZ_STEXT_BLOCK_TEXT) {
                         continue;
@@ -11556,7 +11558,7 @@ struct TextPage {
                     block_dict = PyDict_New();
                     DICT_SETITEM_DROP(block_dict, dictkey_number, Py_BuildValue("i", block_n));
                     DICT_SETITEM_DROP(block_dict, dictkey_bbox,
-                                    JM_py_from_rect(block->bbox));
+                                    JM_py_from_rect(bbox));
                     DICT_SETITEM_DROP(block_dict, dictkey_matrix,
                                     JM_py_from_matrix(block->u.i.transform));
                     DICT_SETITEM_DROP(block_dict, dictkey_width,
@@ -11695,7 +11697,7 @@ struct TextPage {
             fz_rect wbbox = fz_empty_rect;  // word bbox
             fz_stext_page *this_tpage = (fz_stext_page *) $self;
             fz_rect tp_rect = this_tpage->mediabox;
-
+            int word_delimiter = 0;
             PyObject *lines = NULL;
             fz_try(gctx) {
                 buff = fz_new_buffer(gctx, 64);
@@ -11717,10 +11719,12 @@ struct TextPage {
                                 !fz_is_infinite_rect(tp_rect)) {
                                 continue;
                             }
-                            if (ch->c == 32 && buflen == 0)
-                                continue;  // skip spaces at line start
-                            if (ch->c == 32) {
-                                if (!fz_is_empty_rect(wbbox)) {
+                            word_delimiter = JM_is_word_delimiter(ch->c);
+                            if (word_delimiter) {  // encountered end of word
+                                if (buflen == 0) {
+                                    continue;
+                                }
+                                if (!fz_is_empty_rect(wbbox)) {  // output word
                                     word_n = JM_append_word(gctx, lines, buff, &wbbox,
                                                         block_n, line_n, word_n);
                                 }
@@ -11806,10 +11810,10 @@ struct TextPage {
                         fz_print_stext_page_as_xhtml(gctx, out, this_tpage, 0);
                         break;
                     default:
-                        JM_print_stext_page_as_text(gctx, out, this_tpage);
+                        JM_print_stext_page_as_text(gctx, res, this_tpage);
                         break;
                 }
-                text = JM_UnicodeFromBuffer(gctx, res);
+                text = JM_EscapeStrFromBuffer(gctx, res);
 
             }
             fz_always(gctx) {
@@ -12168,6 +12172,7 @@ struct TextWriter
             morph: tuple(Point, Matrix), apply a matrix with a fixpoint.
             matrix: Matrix to be used instead of 'morph' argument.
             render_mode: (int) PDF render mode operator 'Tr'.
+            border_width: (float) stroke line Width. Relevant for render mode > 0.
         """
 
         CheckParent(page)
@@ -12185,6 +12190,8 @@ struct TextWriter
             opacity = self.opacity
         if color is None:
             color = self.color
+        if render_mode < 0:
+            render_mode = 0
         %}
 
         %pythonappend write_text%{
@@ -12234,7 +12241,7 @@ struct TextWriter
                 temp = line.split()
                 fsize = float(temp[1])
                 if render_mode != 0:
-                    w = fsize * 0.05
+                    w = fsize * border_width
                 else:
                     w = 1
                 new_cont_lines.append("%g w" % w)
@@ -12257,7 +12264,7 @@ struct TextWriter
             repair_mono_font(page, font)
         %}
         PyObject *write_text(struct Page *page, PyObject *color=NULL, float opacity=-1, int overlay=1,
-                    PyObject *morph=NULL, PyObject *matrix=NULL, int render_mode=0, int oc=0)
+                    PyObject *morph=NULL, PyObject *matrix=NULL, int render_mode=0, int oc=0, float border_width=0.05)
         {
             pdf_page *pdfpage = pdf_page_from_fz_page(gctx, (fz_page *) page);
             pdf_obj *resources = NULL;
@@ -14409,6 +14416,63 @@ struct Tools
             JM_UNIQUE_ID += 1;
             if (JM_UNIQUE_ID < 0) JM_UNIQUE_ID = 1;
             return Py_BuildValue("i", JM_UNIQUE_ID);
+        }
+
+
+        FITZEXCEPTION(set_word_delimiters, !result)
+        %pythonprepend set_word_delimiters %{
+        """Set characters to be word delimiters."""
+        if delims == None:
+            delims = []
+        if not hasattr(delims, "__getitem__") or len(delims) > 64:
+            raise ValueError("bad delimiter value(s)")
+
+        try:
+            delims = set([ord(c) for c in delims if ord(c) > 32])
+        except:
+            print("bad delimiter value(s)")
+            raise
+        delims = tuple(delims)
+        %}
+        PyObject *set_word_delimiters(PyObject *delims=NULL)
+        {
+            int i, len = (int) PyTuple_Size(delims);
+            if (!len) {
+                word_delimiters[0] = 0; // set list to empty
+                return Py_False;
+            }
+
+            fz_try(gctx) {
+                for (i = 0; i < len; i++) {
+                    word_delimiters[i] = (int) PyLong_AsLong(PyTuple_GET_ITEM(delims, (Py_ssize_t) i));
+                    word_delimiters[i+1] = 0;
+                }
+            }
+            fz_always(gctx) {
+                PyErr_Clear();
+            }
+            fz_catch(gctx) {
+                return NULL;
+            }
+            return Py_True;
+        }
+
+
+        FITZEXCEPTION(get_word_delimiters, !result)
+        %pythonprepend get_word_delimiters %{"""Get the word delimiting characters."""%}
+        PyObject *get_word_delimiters()
+        {
+            int delim, i = 0;
+            PyObject *rc = PyList_New(0);
+            while (1) {
+                delim = word_delimiters[i];
+                if (!delim) {
+                    break;
+                }
+                PyList_Append(rc, Py_BuildValue("C", delim));
+                i++;
+            }
+            return rc;
         }
 
 

--- a/fitz/helper-geo-c.i
+++ b/fitz/helper-geo-c.i
@@ -76,8 +76,8 @@ JM_rect_from_py(PyObject *r)
 
     for (i = 0; i < 4; i++) {
         if (JM_FLOAT_ITEM(r, i, &f[i]) == 1) return fz_infinite_rect;
-        if (f[i] < FZ_MIN_INF_RECT) f[i] = FZ_MIN_INF_RECT;
-        if (f[i] > FZ_MAX_INF_RECT) f[i] = FZ_MAX_INF_RECT;
+        if (f[i] <= FZ_MIN_INF_RECT) f[i] = FZ_MIN_INF_RECT;
+        if (f[i] >= FZ_MAX_INF_RECT) f[i] = FZ_MAX_INF_RECT;
     }
 
     return fz_make_rect((float) f[0], (float) f[1], (float) f[2], (float) f[3]);
@@ -93,6 +93,32 @@ JM_py_from_rect(fz_rect r)
 }
 
 //-----------------------------------------------------------------------------
+// Ignore this rect (generalizes infinite, empty etc.)
+//-----------------------------------------------------------------------------
+int JM_ignore_rect(fz_rect r)
+{
+    if (fz_is_empty_rect(r)) return 1;
+    if (r.x0 >= FZ_MAX_INF_RECT || r.x0 <= FZ_MIN_INF_RECT) return 1;
+    if (r.y0 >= FZ_MAX_INF_RECT || r.y0 <= FZ_MIN_INF_RECT) return 1;
+    if (r.x1 >= FZ_MAX_INF_RECT || r.x1 <= FZ_MIN_INF_RECT) return 1;
+    if (r.y1 >= FZ_MAX_INF_RECT || r.y1 <= FZ_MIN_INF_RECT) return 1;
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+// Ignore this rect (generalizes infinite, empty etc.)
+//-----------------------------------------------------------------------------
+int JM_ignore_irect(fz_irect r)
+{
+    if (fz_is_empty_irect(r)) return 1;
+    if (r.x0 >= FZ_MAX_INF_RECT || r.x0 <= FZ_MIN_INF_RECT) return 1;
+    if (r.y0 >= FZ_MAX_INF_RECT || r.y0 <= FZ_MIN_INF_RECT) return 1;
+    if (r.x1 >= FZ_MAX_INF_RECT || r.x1 <= FZ_MIN_INF_RECT) return 1;
+    if (r.y1 >= FZ_MAX_INF_RECT || r.y1 <= FZ_MIN_INF_RECT) return 1;
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
 // PySequence to fz_irect. Default: infinite irect
 //-----------------------------------------------------------------------------
 static fz_irect
@@ -105,8 +131,8 @@ JM_irect_from_py(PyObject *r)
 
     for (i = 0; i < 4; i++) {
         if (JM_INT_ITEM(r, i, &x[i]) == 1) return fz_infinite_irect;
-        if (x[i] < FZ_MIN_INF_RECT) x[i] = FZ_MIN_INF_RECT;
-        if (x[i] > FZ_MAX_INF_RECT) x[i] = FZ_MAX_INF_RECT;
+        if (x[i] <= FZ_MIN_INF_RECT) x[i] = FZ_MIN_INF_RECT;
+        if (x[i] >= FZ_MAX_INF_RECT) x[i] = FZ_MAX_INF_RECT;
     }
 
     return fz_make_irect(x[0], x[1], x[2], x[3]);

--- a/fitz/helper-globals.i
+++ b/fitz/helper-globals.i
@@ -22,6 +22,9 @@ static int subset_fontnames = 0;
 // Unset ascender / descender corrections
 static int skip_quad_corrections = 0;
 
+// Additional word delimiting characters
+static int word_delimiters[65] = {0};
+
 // constants: error messages
 static const char MSG_BAD_ANNOT_TYPE[] = "bad annot type";
 static const char MSG_BAD_APN[] = "bad or missing annot AP/N";

--- a/fitz/utils.py
+++ b/fitz/utils.py
@@ -536,25 +536,36 @@ def get_text_words(
     flags: OptInt = None,
     textpage: TextPage = None,
     sort: bool = False,
+    delimiters=None,
 ) -> list:
     """Return the text words as a list with the bbox for each word.
 
     Args:
         flags: (int) control the amount of data parsed into the textpage.
+        delimiters: (str,list) characters to use as word delimiters
+
+    Returns:
+        Word tuples (x0, y0, x1, y1, "word", bno, lno, wno).
     """
     CheckParent(page)
     if flags is None:
         flags = TEXT_PRESERVE_WHITESPACE | TEXT_PRESERVE_LIGATURES | TEXT_MEDIABOX_CLIP
+    if delimiters is not None:
+        old_delimiters = TOOLS.get_word_delimiters()
     tp = textpage
     if tp is None:
         tp = page.get_textpage(clip=clip, flags=flags)
     elif getattr(tp, "parent") != page:
         raise ValueError("not a textpage of this page")
+    if delimiters is not None:
+        TOOLS.set_word_delimiters(delimiters)
     words = tp.extractWORDS()
     if textpage is None:
         del tp
     if sort is True:
         words.sort(key=lambda w: (w[3], w[0]))
+    if delimiters is not None:
+        TOOLS.set_word_delimiters(old_delimiters)
     return words
 
 
@@ -751,6 +762,7 @@ def get_text(
     flags: OptInt = None,
     textpage: TextPage = None,
     sort: bool = False,
+    delimiters=None,
 ):
     """Extract text from a page or an annotation.
 
@@ -791,7 +803,12 @@ def get_text(
 
     if option == "words":
         return get_text_words(
-            page, clip=clip, flags=flags, textpage=textpage, sort=sort
+            page,
+            clip=clip,
+            flags=flags,
+            textpage=textpage,
+            sort=sort,
+            delimiters=delimiters,
         )
     if option == "blocks":
         return get_text_blocks(
@@ -1725,7 +1742,7 @@ def insert_textbox(
     align: int = 0,
     rotate: int = 0,
     render_mode: int = 0,
-    border_width: float = 1,
+    border_width: float = 0.05,
     morph: OptSeq = None,
     overlay: bool = True,
     stroke_opacity: float = 1,
@@ -1791,7 +1808,7 @@ def insert_text(
     encoding: int = 0,
     color: OptSeq = None,
     fill: OptSeq = None,
-    border_width: float = 1,
+    border_width: float = 0.05,
     render_mode: int = 0,
     rotate: int = 0,
     morph: OptSeq = None,
@@ -3430,7 +3447,7 @@ class Shape(object):
         color: OptSeq = None,
         fill: OptSeq = None,
         render_mode: int = 0,
-        border_width: float = 1,
+        border_width: float = 0.05,
         rotate: int = 0,
         morph: OptSeq = None,
         stroke_opacity: float = 1,
@@ -3561,10 +3578,11 @@ class Shape(object):
         else:
             alpha = "/%s gs\n" % alpha
         nres = templ1 % (bdc, alpha, cm, left, top, fname, fontsize)
+
         if render_mode > 0:
             nres += "%i Tr " % render_mode
-        if border_width != 1:
-            nres += "%g w " % border_width
+            nres += "%g w " % border_width * fontsize
+
         if color is not None:
             nres += color_str
         if fill is not None:
@@ -3590,16 +3608,16 @@ class Shape(object):
 
         nres += "\nET\n%sQ\n" % emc
 
-        # =========================================================================
+        # =====================================================================
         #   end of text insertion
-        # =========================================================================
+        # =====================================================================
         # update the /Contents object
         self.text_cont += nres
         return nlines
 
-    # ==============================================================================
+    # =========================================================================
     # Shape.insert_textbox
-    # ==============================================================================
+    # =========================================================================
     def insert_textbox(
         self,
         rect: rect_like,
@@ -3613,7 +3631,7 @@ class Shape(object):
         color: OptSeq = None,
         fill: OptSeq = None,
         expandtabs: int = 1,
-        border_width: float = 1,
+        border_width: float = 0.05,
         align: int = 0,
         render_mode: int = 0,
         rotate: int = 0,
@@ -3634,7 +3652,7 @@ class Shape(object):
             color -- RGB stroke color triple
             fill -- RGB fill color triple
             render_mode -- text rendering control
-            border_width -- thickness of glyph borders
+            border_width -- thickness of glyph borders as percentage of fontsize
             expandtabs -- handles tabulators with string function
             align -- left, center, right, justified
             rotate -- 0, 90, 180, or 270 degrees
@@ -3737,7 +3755,7 @@ class Shape(object):
             else:
                 return len(x) * fontsize
 
-        # ----------------------------------------------------------------------
+        # ---------------------------------------------------------------------
 
         if ordering < 0:
             blen = glyphs[32][1] * fontsize  # pixel size of space character
@@ -3755,99 +3773,107 @@ class Shape(object):
         else:
             cm = ""
 
-        # ---------------------------------------------------------------------------
+        # ---------------------------------------------------------------------
         # adjust for text orientation / rotation
-        # ---------------------------------------------------------------------------
+        # ---------------------------------------------------------------------
         progr = 1  # direction of line progress
         c_pnt = Point(0, fontsize * ascender)  # used for line progress
         if rot == 0:  # normal orientation
             point = rect.tl + c_pnt  # line 1 is 'lheight' below top
-            pos = point.y + self.y  # y of first line
             maxwidth = rect.width  # pixels available in one line
-            maxpos = rect.y1 + self.y  # lines must not be below this
+            maxheight = rect.height  # available text height
 
         elif rot == 90:  # rotate counter clockwise
             c_pnt = Point(fontsize * ascender, 0)  # progress in x-direction
             point = rect.bl + c_pnt  # line 1 'lheight' away from left
-            pos = point.x + self.x  # position of first line
             maxwidth = rect.height  # pixels available in one line
-            maxpos = rect.x1 + self.x  # lines must not be right of this
+            maxheight = rect.width  # available text height 
             cm += cmp90
 
         elif rot == 180:  # text upside down
             # progress upwards in y direction
             c_pnt = -Point(0, fontsize * ascender)
             point = rect.br + c_pnt  # line 1 'lheight' above bottom
-            pos = point.y + self.y  # position of first line
             maxwidth = rect.width  # pixels available in one line
             progr = -1  # subtract lheight for next line
-            maxpos = rect.y0 + self.y  # lines must not be above this
+            maxheight =rect.height  # available text height
             cm += cm180
 
         else:  # rotate clockwise (270 or -90)
             # progress from right to left
             c_pnt = -Point(fontsize * ascender, 0)
             point = rect.tr + c_pnt  # line 1 'lheight' left of right
-            pos = point.x + self.x  # position of first line
             maxwidth = rect.height  # pixels available in one line
             progr = -1  # subtract lheight for next line
-            maxpos = rect.x0 + self.x  # lines must not left of this
+            maxheight = rect.width  # available text height 
             cm += cmm90
 
-        # =======================================================================
+        # =====================================================================
         # line loop
-        # =======================================================================
+        # =====================================================================
         just_tab = []  # 'justify' indicators per line
 
         for i, line in enumerate(t0):
             line_t = line.expandtabs(expandtabs).split(" ")  # split into words
+            num_words = len(line_t)
             lbuff = ""  # init line buffer
             rest = maxwidth  # available line pixels
-            # ===================================================================
+            # =================================================================
             # word loop
-            # ===================================================================
-            for word in line_t:
+            # =================================================================
+            for j in range(num_words):
+                word = line_t[j]
                 pl_w = pixlen(word)  # pixel len of word
-                if rest >= pl_w:  # will it fit on the line?
-                    lbuff += word + " "  # yes, and append word
+                if rest >= pl_w:  # does it fit on the line?
+                    lbuff += word + " "  # yes, append word
                     rest -= pl_w + blen  # update available line space
-                    continue
-                # word won't fit - output line (if not empty)
-                if len(lbuff) > 0:
+                    continue  # next word
+
+                # word doesn't fit - output line (if not empty)
+                if lbuff:
                     lbuff = lbuff.rstrip() + "\n"  # line full, append line break
                     text += lbuff  # append to total text
-                    pos += lheight * progr  # increase line position
-                    just_tab.append(True)  # line is justify candidate
-                    lbuff = ""  # re-init line buffer
+                    just_tab.append(True)  # can align-justify
+
+                lbuff = ""  # re-init line buffer
                 rest = maxwidth  # re-init avail. space
+
                 if pl_w <= maxwidth:  # word shorter than 1 line?
                     lbuff = word + " "  # start the line with it
                     rest = maxwidth - pl_w - blen  # update free space
                     continue
+
                 # long word: split across multiple lines - char by char ...
                 if len(just_tab) > 0:
-                    just_tab[-1] = False  # reset justify indicator
+                    just_tab[-1] = False  # cannot align-justify
                 for c in word:
                     if pixlen(lbuff) <= maxwidth - pixlen(c):
                         lbuff += c
                     else:  # line full
                         lbuff += "\n"  # close line
                         text += lbuff  # append to text
-                        pos += lheight * progr  # increase line position
-                        just_tab.append(False)  # do not justify line
+                        just_tab.append(False)  # cannot align-justify
                         lbuff = c  # start new line with this char
+
                 lbuff += " "  # finish long word
                 rest = maxwidth - pixlen(lbuff)  # long word stored
 
-            if lbuff != "":  # unprocessed line content?
+            if lbuff:  # unprocessed line content?
                 text += lbuff.rstrip()  # append to text
-                just_tab.append(False)  # do not justify line
+                just_tab.append(False)  # cannot align-justify
+
             if i < len(t0) - 1:  # not the last line?
                 text += "\n"  # insert line break
-                pos += lheight * progr  # increase line position
 
-        more = (pos - maxpos) * progr  # difference to rect size limit
+        # compute used part of the textbox
+        if text.endswith("\n"):
+            text=text[:-1]
+        lb_count = text.count("\n") + 1 # number of lines written
 
+        # text height = line count * line height plus one descender value
+        text_height = lheight * lb_count - descender * fontsize
+
+        more = text_height - maxheight  # difference to height limit
         if more > EPSILON:  # landed too much outside rect
             return (-1) * more  # return deficit, don't output
 
@@ -3891,8 +3917,11 @@ class Shape(object):
                 top = -height + pnt.y + self.y
 
             nres += templ % (left, top, fname, fontsize)
+
             if render_mode > 0:
                 nres += "%i Tr " % render_mode
+                nres += "%g w " % border_width * fontsize
+
             if align == 3:
                 nres += "%g Tw " % spacing
 
@@ -3900,8 +3929,6 @@ class Shape(object):
                 nres += color_str
             if fill is not None:
                 nres += fill_str
-            if border_width != 1:
-                nres += "%g w " % border_width
             nres += "%sTJ\n" % getTJstr(t, tj_glyphs, simple, ordering)
 
         nres += "ET\n%sQ\n" % emc


### PR DESCRIPTION
This change offers to define up to 64 additional characters for use as delimiters in page.get_text("words"). Delimiters can be set either temporarily in the method itself, or permanently for all subsequent word extractions.

Please note that in rebased, no respective changes were made in extra.i. Any speed boosting will need extra code there.

Other changes:

* plain text output characters are now handled the same way as in all other extraction variants. This entails using fz_buffer as intermediate storage for extracted text - not any longer fz_output.

* in rare cases, fz_stext_page returns invalid bboxes for images or text: not empty, not infinite, but still with one or more of its edges having coordinates in common with the infinite rectangle. We define a new function "JM_ignore_rect()" to allow filtering out (ignoring) them.

* finally fixed typo in issue #2522

* added TOOLS.store_shrink() to Document method "reload_page()" to ensure the absence of cached, now possibly invalid objects pertaining to this page.

* When adding annotation to a page, removed unnecessary (possibly even wrong) extra annotation flag settings, so now MuPDF's defaults will prevail.

* Added flexibility to border_width parameter in Page methods "insert_text"/"insert_textbox". This is now interpreted as a fraction of font size, such that e.g. a value of 0.05 corresponds to a border width of 5% of the font size.