### PR TITLE
Word delimiters

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -11688,7 +11688,7 @@ struct TextPage {
         %pythonprepend extractWORDS
         %{"""Return a list with text word information."""%}
         PyObject *
-        extractWORDS()
+        extractWORDS(PyObject *delimiters=NULL)
         {
             fz_stext_block *block;
             fz_stext_line *line;
@@ -11700,7 +11700,7 @@ struct TextPage {
             fz_rect wbbox = fz_empty_rect;  // word bbox
             fz_stext_page *this_tpage = (fz_stext_page *) $self;
             fz_rect tp_rect = this_tpage->mediabox;
-
+            int word_delimiter = 0;
             PyObject *lines = NULL;
             fz_try(gctx) {
                 buff = fz_new_buffer(gctx, 64);
@@ -11722,10 +11722,10 @@ struct TextPage {
                                 !fz_is_infinite_rect(tp_rect)) {
                                 continue;
                             }
-                            if (ch->c == 32 && buflen == 0)
-                                continue;  // skip spaces at line start
-                            if (ch->c == 32) {
-                                if (!fz_is_empty_rect(wbbox)) {
+                            word_delimiter = JM_is_word_delimiter(ch->c, delimiters);
+                            if (word_delimiter)
+                                if (buflen == 0) continue;  // skip spaces at line start
+                                if (!fz_is_empty_rect(wbbox)) {  // output word
                                     word_n = JM_append_word(gctx, lines, buff, &wbbox,
                                                         block_n, line_n, word_n);
                                 }

--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -11723,7 +11723,7 @@ struct TextPage {
                                 continue;
                             }
                             word_delimiter = JM_is_word_delimiter(ch->c, delimiters);
-                            if (word_delimiter)
+                            if (word_delimiter) {
                                 if (buflen == 0) continue;  // skip spaces at line start
                                 if (!fz_is_empty_rect(wbbox)) {  // output word
                                     word_n = JM_append_word(gctx, lines, buff, &wbbox,

--- a/fitz/utils.py
+++ b/fitz/utils.py
@@ -554,7 +554,8 @@ def get_text_words(
         tp = page.get_textpage(clip=clip, flags=flags)
     elif getattr(tp, "parent") != page:
         raise ValueError("not a textpage of this page")
-    words = tp.extractWORDS()
+
+    words = tp.extractWORDS(delimiters)
     if textpage is None:
         del tp
     if sort is True:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12079,10 +12079,10 @@ class TextPage:
             rc = ''
         return rc
 
-    def extractWORDS(self):
+    def extractWORDS(self, delimiters=None):
         """Return a list with text word information."""
         if g_use_extra:
-            return extra.extractWORDS(self.this)
+            return extra.extractWORDS(self.this, delimiters)
         buflen = 0
         block_n = -1
         wbbox = mupdf.FzRect(mupdf.FzRect.Fixed_EMPTY)  # word bbox
@@ -12108,9 +12108,10 @@ class TextPage:
                             and not mupdf.fz_is_infinite_rect(tp_rect)
                             ):
                         continue
-                    if ch.m_internal.c == 32 and buflen == 0:
-                        continue    # skip spaces at line start
-                    if ch.m_internal.c == 32:
+                    word_delimiter = JM_is_word_delimiter(ch.m_internal.c, delimiters)
+                    if word_delimiter:
+                        if buflen == 0:
+                            continue    # skip delimiters at line start
                         if not mupdf.fz_is_empty_rect(wbbox):
                             word_n, wbbox = JM_append_word(lines, buff, wbbox, block_n, line_n, word_n)
                         mupdf.fz_clear_buffer(buff)
@@ -14617,6 +14618,20 @@ def JM_font_descender(font):
         return -0.2
     ret = mupdf.fz_font_descender(font)
     return ret
+
+
+def JM_is_word_delimiter(ch, delimiters):
+    """Check if ch is an extra word delimiting character.
+    """
+    if ch <= 32 or ch == 160:  # any whitespace?
+        return True
+    if not delimiters:  # no extra delimiters provided
+        return False
+    char = chr(ch)
+    for d in delimiters:
+        if d == char:
+            return True
+    return False
 
 
 def JM_font_name(font):

--- a/src/extra.i
+++ b/src/extra.i
@@ -3546,7 +3546,7 @@ PyObject* extractWORDS(mupdf::FzStextPage& this_tpage, PyObject *delimiters)
                     continue;
                 }
 
-                word_delimiter = JM_is_word_delimiter(ch.m_internal->c, delimiters);
+                int word_delimiter = JM_is_word_delimiter(ch.m_internal->c, delimiters);
                 if (word_delimiter)
                 {
                     if (buflen == 0)
@@ -4369,7 +4369,7 @@ mupdf::FzRect JM_make_spanlist(
         mupdf::FzRect& tp_rect
         );
 
-PyObject* extractWORDS(mupdf::FzStextPage& this_tpage);
+PyObject* extractWORDS(mupdf::FzStextPage& this_tpage, PyObject *delimiters);
 PyObject* extractBLOCKS(mupdf::FzStextPage& self);
 
 PyObject* link_uri(mupdf::FzLink& link);

--- a/src/utils.py
+++ b/src/utils.py
@@ -557,7 +557,8 @@ def get_text_words(
         tp = page.get_textpage(clip=clip, flags=flags)
     elif getattr(tp, "parent") != page:
         raise ValueError("not a textpage of this page")
-    words = tp.extractWORDS()
+
+    words = tp.extractWORDS(delimiters)
     if textpage is None:
         del tp
     if sort is True:

--- a/tests/test_word_delimiters.py
+++ b/tests/test_word_delimiters.py
@@ -1,0 +1,21 @@
+import fitz
+import string
+
+
+def test_delimiters():
+    """Test changing word delimiting characters."""
+    doc = fitz.open()
+    page = doc.new_page()
+    text = "word1,word2 - word3. word4?word5."
+    page.insert_text((50, 50), text)
+
+    # Standard words extraction:
+    # only spaces and line breaks start a new word
+    words0 = [w[4] for w in page.get_text("words")]
+
+    # extract words again
+    words1 = [w[4] for w in page.get_text("words", delimiters=string.punctuation)]
+    assert " ".join(words1) == "word1 word2 word3 word4 word5"
+
+    # confirm we will be getting old extraction
+    assert [w[4] for w in page.get_text("words")] == words0

--- a/tests/test_word_delimiters.py
+++ b/tests/test_word_delimiters.py
@@ -15,6 +15,7 @@ def test_delimiters():
 
     # extract words again
     words1 = [w[4] for w in page.get_text("words", delimiters=string.punctuation)]
+    assert words0 != words1
     assert " ".join(words1) == "word1 word2 word3 word4 word5"
 
     # confirm we will be getting old extraction

--- a/tests/test_word_delimiters.py
+++ b/tests/test_word_delimiters.py
@@ -12,6 +12,7 @@ def test_delimiters():
     # Standard words extraction:
     # only spaces and line breaks start a new word
     words0 = [w[4] for w in page.get_text("words")]
+    assert words0 == ["word1,word2", "-", "word3.", "word4?word5."]
 
     # extract words again
     words1 = [w[4] for w in page.get_text("words", delimiters=string.punctuation)]


### PR DESCRIPTION
This feature introduces the option to define extra word delimiting characters (beyond the standard white space) for text extraction variant "words".
A typical use is splitting strings into words also at punctuations. By default, "john.doe@outlook.com" will be returned as one word. Using `delimiters=".@"` will return the 4 word components.