### PR TITLE
Support checking valid PDF name objects

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -309,6 +309,10 @@ import re
 import tarfile
 import zipfile
 import pathlib
+import string
+
+# PDF names must not contain these characters:
+INVALID_NAME_CHARS = set(string.whitespace + "()<>[]{}/%" + chr(0))
 
 TESSDATA_PREFIX = os.getenv("TESSDATA_PREFIX")
 point_like = "point_like"
@@ -7372,6 +7376,9 @@ def insert_font(self, fontname="helv", fontfile=None, fontbuffer=None,
 
     if fontname.startswith("/"):
         fontname = fontname[1:]
+    inv_chars = INVALID_NAME_CHARS.intersection(fontname)
+    if inv_chars != set():
+        raise ValueError(f"bad fontname chars {inv_chars}")
 
     font = CheckFont(self, fontname)
     if font is not None:                    # font already in font list of page

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -55,9 +55,12 @@ import typing
 import warnings
 import weakref
 import zipfile
+import string
 
 from . import extra
 
+# PDF names must not contain these characters:
+INVALID_NAME_CHARS = set(string.whitespace + "()<>[]{}/%" + chr(0))
 
 def get_env_bool( name, default):
     '''
@@ -8810,6 +8813,9 @@ class Page:
 
         if fontname.startswith("/"):
             fontname = fontname[1:]
+        inv_chars = INVALID_NAME_CHARS.intersection(fontname)
+        if inv_chars != set():
+            raise ValueError(f"bad fontname chars {inv_chars}")
 
         font = CheckFont(self, fontname)
         if font is not None:                    # font already in font list of page

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -29,10 +29,10 @@ def test_fontname():
     """Assert a valid PDF fontname."""
     doc = fitz.open()
     page = doc.new_page()
-    assert page.insert_font()
+    assert page.insert_font()  # assert: a valid fontname works!
     detected = False  # preset indicator
-    try:
-        page.insert_font(fontname="illegal/char", fontbuffer=b"unimportant")
+    try:  # fontname check will fail first - don't need a font at all here
+        page.insert_font(fontname="illegal/char", fontfile="unimportant")
     except ValueError as e:
         if str(e).startswith("bad fontname chars"):
             detected = True  # illegal fontname detected

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -23,3 +23,17 @@ def test_font2():
     font = fitz.Font("helv")
     text = "PyMuPDF"
     assert font.text_length(text) == fitz.get_text_length(text)
+
+
+def test_fontname():
+    """Assert a valid PDF fontname."""
+    doc = fitz.open()
+    page = doc.new_page()
+    font = fitz.Font("helv")
+    assert page.insert_font(fontname="legal", fontbuffer=font.buffer)
+    detected = False  # preset indicator
+    try:
+        page.insert_font(fontname="illegal/char", fontbuffer=font.buffer)
+    except ValueError:
+        detected = True  # illegal fontname detected
+    assert detected

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -30,7 +30,7 @@ def test_fontname():
     doc = fitz.open()
     page = doc.new_page()
     font = fitz.Font("helv")
-    assert page.insert_font(fontname="legal", fontbuffer=font.buffer)
+    assert page.insert_font()
     detected = False  # preset indicator
     try:
         page.insert_font(fontname="illegal/char", fontbuffer=font.buffer)

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -29,11 +29,11 @@ def test_fontname():
     """Assert a valid PDF fontname."""
     doc = fitz.open()
     page = doc.new_page()
-    font = fitz.Font("helv")
     assert page.insert_font()
     detected = False  # preset indicator
     try:
-        page.insert_font(fontname="illegal/char", fontbuffer=font.buffer)
-    except ValueError:
-        detected = True  # illegal fontname detected
+        page.insert_font(fontname="illegal/char", fontbuffer=b"unimportant")
+    except ValueError as e:
+        if str(e).startswith("bad fontname chars"):
+            detected = True  # illegal fontname detected
     assert detected


### PR DESCRIPTION
Defines a Python set of characters that are illegal in PDF names. We are currently checking validity of font reference names.