### PR TITLE
Set key name checks

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -815,7 +815,15 @@ struct Document
 
 
         FITZEXCEPTION(xref_set_key, !result)
-        CLOSECHECK0(xref_set_key, """Set the value of a PDF dictionary key.""")
+        %pythonprepend %{
+        """Set the value of a PDF dictionary key."""
+        if self.is_closed or self.is_encrypted:
+            raise ValueError("document closed or encrypted")
+        if not key or not isinstance(key, str) or INVALID_NAME_CHARS.intersection(key) not in (set(), {"/"}):
+            raise ValueError("bad 'key'")
+        if not isinstance(value, str) or not value or value[0] == "/" and INVALID_NAME_CHARS.intersection(value[1:]) != set():
+            raise ValueError("bad 'value'")
+        %}
         PyObject *
         xref_set_key(int xref, const char *key, char *value)
         {

--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -815,7 +815,7 @@ struct Document
 
 
         FITZEXCEPTION(xref_set_key, !result)
-        %pythonprepend %{
+        %pythonprepend xref_set_key %{
         """Set the value of a PDF dictionary key."""
         if self.is_closed or self.is_encrypted:
             raise ValueError("document closed or encrypted")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5670,12 +5670,14 @@ class Document:
         """Set the value of a PDF dictionary key."""
         if self.is_closed:
             raise ValueError("document closed")
+
+        if not key or not isinstance(key, str) or INVALID_NAME_CHARS.intersection(key) not in (set(), {"/"}):
+            raise ValueError("bad 'key'")
+        if not isinstance(value, str) or not value or value[0] == "/" and INVALID_NAME_CHARS.intersection(value[1:]) != set():
+            raise ValueError("bad 'value'")
+
         pdf = _as_pdf_document(self)
         ASSERT_PDF(pdf)
-        if not key:
-            raise ValueError( "bad 'key'")
-        if not value:
-            raise ValueError( "bad 'value'")
         xreflen = mupdf.pdf_xref_len(pdf)
         #if not _INRANGE(xref, 1, xreflen-1) and xref != -1:
         #    THROWMSG("bad xref")


### PR DESCRIPTION
This change uses the new PDF name verification to confirm that exclusively valid PDF names are specified as parameters in`Document.xref_set_key()` for the key and the value parameter.