### PR TITLE
Support flexible delimiters

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -19,11 +19,17 @@ Change Log
   * **Fixed** `2730 <https://github.com/pymupdf/PyMuPDF/issues/2730>`_: persistent get_text() formatting
 
 * Other:
+
   * Use MuPDF-1.23.4.
+
   * Fix optimisation flags with system installs.
+
   * Fixed the problem that the clip parameter does not take effect during table recognition
+
   * Support Pillow mode "RGBa"
+
   * Support extra word delimiters
+
   * Support checking valid PDF name objects
 
 

--- a/changes.txt
+++ b/changes.txt
@@ -21,15 +21,10 @@ Change Log
 * Other:
 
   * Use MuPDF-1.23.4.
-
   * Fix optimisation flags with system installs.
-
   * Fixed the problem that the clip parameter does not take effect during table recognition
-
   * Support Pillow mode "RGBa"
-
   * Support extra word delimiters
-
   * Support checking valid PDF name objects
 
 

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -633,7 +633,7 @@ Yet others are handy, general-purpose utilities.
 
 -----
 
-   .. method:: Page.get_text_words(flags=None)
+   .. method:: Page.get_text_words(flags=None, delimiters=None)
 
       Deprecated wrapper for :meth:`TextPage.extractWORDS`. Use :meth:`Page.get_text` with the "words" option instead.
 

--- a/docs/page.rst
+++ b/docs/page.rst
@@ -1057,14 +1057,16 @@ In a nutshell, this is what you can do with PyMuPDF:
       pair: xml; Page.get_text
       pair: textpage; Page.get_text
       pair: sort; Page.get_text
+      pair: delimiters; Page.get_text
 
-   .. method:: get_text(opt,*, clip=None, flags=None, textpage=None, sort=False)
+   .. method:: get_text(opt,*, clip=None, flags=None, textpage=None, sort=False, delimiters=None)
 
       * Changed in v1.19.0: added `textpage` parameter
       * Changed in v1.19.1: added `sort` parameter
       * Changed in v1.19.6: added new constants for defining default flags per method.
+      * Changed in v1.23.5: added `delimiters` parameter
 
-      Retrieves the content of a page in a variety of formats. This is a wrapper for :ref:`TextPage` methods by choosing the output option as follows:
+      Retrieves the content of a page in a variety of formats. This is a wrapper for multiple :ref:`TextPage` methods by choosing the output option `opt` as follows:
 
       * "text" -- :meth:`TextPage.extractTEXT`, default
       * "blocks" -- :meth:`TextPage.extractBLOCKS`
@@ -1088,6 +1090,8 @@ In a nutshell, this is what you can do with PyMuPDF:
       :arg textpage: (new in v1.19.0) use a previously created :ref:`TextPage`. This reduces execution time **very significantly:** by more than 50% and up to 95%, depending on the extraction option. If specified, the 'flags' and 'clip' arguments are ignored, because they are textpage-only properties. If omitted, a new, temporary textpage will be created.
 
       :arg bool sort: (new in v1.19.1) sort the output by vertical, then horizontal coordinates. In many cases, this should suffice to generate a "natural" reading order. Has no effect on (X)HTML and XML. Output option **"words"** sorts by `(y1, x0)` of the words' bboxes. Similar is true for "blocks", "dict", "json", "rawdict", "rawjson": they all are sorted by `(y1, x0)` of the resp. block bbox. If specified for "text", then internally "blocks" is used.
+
+      :arg str delimiters: (new in v1.23.5) use these characters as *additional* word separators with the "words" output option (ignored otherwise). By default, all white spaces (including non-breaking space `0xA0`) indicate start and end of a word. Now you can specify more characters causing this. For instance, the default will return `"john.doe@outlook.com"` as **one** word. If you specify `delimiters="@."` then the **four** words `"john"`, `"doe"`, `"outlook"`, `"com"` will be returned. Other possible uses include ignoring punctuation characters `delimiters=string.punctuation`. The "word" strings will not contain any delimiting character.
 
       :rtype: *str, list, dict*
       :returns: The page's content as a string, a list or a dictionary. Refer to the corresponding :ref:`TextPage` method for details.

--- a/docs/recipes-text.rst
+++ b/docs/recipes-text.rst
@@ -148,7 +148,7 @@ But you also have other options::
      """Underline each word that contains 'text'.
      """
      found = 0
-     wlist = page.get_text("words")  # make the word list
+     wlist = page.get_text("words", delimiters=None)  # make the word list
      for w in wlist:  # scan through all words on page
          if text in w[4]:  # w[4] is the word's string
              found += 1  # count
@@ -173,10 +173,10 @@ But you also have other options::
  if new_doc:
      doc.save("marked-" + doc.name)
 
-This script uses `Page.get_text("words")` to look for a string, handed in via cli parameter. This method separates a page's text into "words" using spaces and line breaks as delimiters. Further remarks:
+This script uses `Page.get_text("words")` to look for a string, handed in via cli parameter. This method separates a page's text into "words" using white spaces as delimiters. Further remarks:
 
 * If found, the **complete word containing the string** is marked (underlined) -- not only the search string.
-* The search string may **not contain spaces** or other white space.
+* The search string may **not contain word delimiters**. By default, word delimiters are white spaces and the non-breaking space `chr(0xA0)`. If you use extra delimiting characters like `page.get_text("words", delimiters="./,")` then none of these characters should be included in your search string either.
 * As shown here, upper / lower cases are **respected**. But this can be changed by using the string method *lower()* (or even regular expressions) in function *mark_word*.
 * There is **no upper limit**: all occurrences will be detected.
 * You can use **anything** to mark the word: 'Underline', 'Highlight', 'StrikeThrough' or 'Square' annotations, etc.
@@ -201,14 +201,14 @@ This script searches for text and marks it::
     doc = fitz.open("tilted-text.pdf")
 
     # the text to be marked
-    t = "¡La práctica hace el campeón!"
+    needle = "¡La práctica hace el campeón!"
 
     # work with first page only
     page = doc[0]
 
     # get list of text locations
     # we use "quads", not rectangles because text may be tilted!
-    rl = page.search_for(t, quads = True)
+    rl = page.search_for(needle, quads=True)
 
     # mark all found quads with one annotation
     page.add_squiggly_annot(rl)

--- a/docs/textpage.rst
+++ b/docs/textpage.rst
@@ -58,13 +58,17 @@ For a description of what this class is all about, see Appendix 2.
 
       :rtype: list
 
-   .. method:: extractWORDS
+   .. method:: extractWORDS(delimiters=None)
+
+      * Changed in v1.23.5: added `delimiters` parameter
 
       Textpage content as a list of single words with bbox information. An item of this list looks like this::
 
          (x0, y0, x1, y1, "word", block_no, line_no, word_no)
 
-      Everything delimited by spaces is treated as a *"word"*. This is a high-speed method which e.g. allows extracting text from within given areas or recovering the text reading sequence.
+      :arg str delimiters: (new in v1.23.5) use these characters as *additional* word separators. By default, all white spaces (including the non-breaking space `0xA0`) indicate start and end of a word. Now you can specify more characters causing this. For instance, the default will return `"john.doe@outlook.com"` as **one** word. If you specify `delimiters="@."` then the **four** words `"john"`, `"doe"`, `"outlook"`, `"com"` will be returned. Other possible uses include ignoring punctuation characters `delimiters=string.punctuation`. The "word" strings will not contain any delimiting character.
+
+      This is a high-speed method which e.g. allows extracting text from within given areas or recovering the text reading sequence.
 
       :rtype: list
 


### PR DESCRIPTION
Introduce flexible delimiting characters for "words" text extraction.
Also make changes to file `changes.txt` to cause correct line breaks when embedded in a RST file.