### PR TITLE
Fixing 2812

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,4 +1,6 @@
 import os
+import io
+from pprint import pprint
 import fitz
 import pickle
 
@@ -30,3 +32,115 @@ def test_table2():
     assert tab1.header.cells == tab1.rows[0].cells
     assert tab2.header.external == False
     assert tab2.header.cells == tab2.rows[0].cells
+
+
+def test_2812():
+    """Ensure table detection and extraction independent from page rotation.
+
+    Make 4 pages with rotations 0, 90, 180 and 270 degrees respectively.
+    Each page shows the same 8x5 table.
+    We will check that each table is detected and delivers the same content.
+    """
+    doc = fitz.open()
+    # Page 0: rotation 0
+    page = doc.new_page(width=842, height=595)
+    rect = page.rect + (72, 72, -72, -72)
+    cols = 5
+    rows = 8
+    # define the cells, draw the grid and insert unique text in each cell.
+    cells = fitz.make_table(rect, rows=rows, cols=cols)
+    for i in range(rows):
+        for j in range(cols):
+            page.draw_rect(cells[i][j])
+    for i in range(rows):
+        for j in range(cols):
+            page.insert_textbox(
+                cells[i][j],
+                f"cell[{i}][{j}]",
+                align=fitz.TEXT_ALIGN_CENTER,
+            )
+    page.clean_contents()
+
+    # Page 1: rotation 90 degrees
+    page = doc.new_page()
+    rect = page.rect + (72, 72, -72, -72)
+    cols = 8
+    rows = 5
+    cells = fitz.make_table(rect, rows=rows, cols=cols)
+    for i in range(rows):
+        for j in range(cols):
+            page.draw_rect(cells[i][j])
+    for i in range(rows):
+        for j in range(cols):
+            page.insert_textbox(
+                cells[i][j],
+                f"cell[{j}][{rows-i-1}]",
+                rotate=90,
+                align=fitz.TEXT_ALIGN_CENTER,
+            )
+    page.set_rotation(90)
+    page.clean_contents()
+
+    # Page 2: rotation 180 degrees
+    page = doc.new_page(width=842, height=595)
+    rect = page.rect + (72, 72, -72, -72)
+    cols = 5
+    rows = 8
+    cells = fitz.make_table(rect, rows=rows, cols=cols)
+    for i in range(rows):
+        for j in range(cols):
+            page.draw_rect(cells[i][j])
+    for i in range(rows):
+        for j in range(cols):
+            page.insert_textbox(
+                cells[i][j],
+                f"cell[{rows-i-1}][{cols-j-1}]",
+                rotate=180,
+                align=fitz.TEXT_ALIGN_CENTER,
+            )
+    page.set_rotation(180)
+    page.clean_contents()
+
+    # Page 3: rotation 270 degrees
+    page = doc.new_page()
+    rect = page.rect + (72, 72, -72, -72)
+    cols = 8
+    rows = 5
+    cells = fitz.make_table(rect, rows=rows, cols=cols)
+    for i in range(rows):
+        for j in range(cols):
+            page.draw_rect(cells[i][j])
+    for i in range(rows):
+        for j in range(cols):
+            page.insert_textbox(
+                cells[i][j],
+                f"cell[{cols-j-1}][{i}]",
+                rotate=270,
+                align=fitz.TEXT_ALIGN_CENTER,
+            )
+    page.set_rotation(270)
+    page.clean_contents()
+
+    pdfdata = doc.tobytes()
+    # doc.ez_save("test-2812.pdf")
+    doc.close()
+
+    # -------------------------------------------------------------------------
+    # Test PDF prepared. Extract table on each page and
+    # ensure identical extracted table data.
+    # -------------------------------------------------------------------------
+    doc = fitz.open("pdf", pdfdata)
+    extracts = []
+    for page in doc:
+        tabs = page.find_tables()
+        assert len(tabs.tables) == 1
+        tab = tabs[0]
+        fp = io.StringIO()
+        pprint(tab.extract(), stream=fp)
+        extracts.append(fp.getvalue())
+        fp = None
+        assert tab.row_count == 8
+        assert tab.col_count == 5
+    e0 = extracts[0]
+    for e in extracts[1:]:
+        assert e == e0


### PR DESCRIPTION
This fixes #2812.
We did not handle correctly tables present on rotated pages - for details see the issue.
The problem has been addressed by correctly setting the page dimension in the clip for vector graphics detection and by using genuine PyMuPDF code for cell text extraction.