### PR TITLE
Optional extraction of characters and glyph names

### DIFF
--- a/fitz/fitz.i
+++ b/fitz/fitz.i
@@ -6572,13 +6572,13 @@ def get_oc_items(self) -> list:
             self.set_rotation(old_rotation)
         %}
         PyObject *
-        get_texttrace()
+        get_texttrace(PyObject *names=NULL)
         {
             fz_page *page = (fz_page *) $self;
             fz_device *dev = NULL;
             PyObject *rc = PyList_New(0);
             fz_try(gctx) {
-                dev = JM_new_texttrace_device(gctx, rc);
+                dev = JM_new_texttrace_device(gctx, rc, PyObject_IsTrue(names));
                 fz_rect prect = fz_bound_page(gctx, page);
                 trace_device_rot = fz_identity;
                 trace_device_ptm = fz_make_matrix(1, 0, 0, -1, 0, prect.y1);

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -257,6 +257,27 @@ def test_texttrace():
             print( f'page {i} json:\n{json.dumps(tt, indent="    ")}', file=f)
 
 
+def test_glyphnames2():
+    """Test extraction of characters and glyph names."""
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((100, 100), "World !")
+    compare = [
+        ("W", "W"),
+        ("o", "o"),
+        ("r", "r"),
+        ("l", "l"),
+        ("d", "d"),
+        (" ", "space"),
+        ("!", "exclam"),
+    ]
+    # this invocation returns chr() and glyph name,
+    # instead of corresponding integers.
+    spans = page.get_texttrace(names=True)
+    new = [(i[0], i[1]) for i in spans[0]["chars"]]
+    assert compare == new
+
+
 def test_2533():
     """Assert correct char bbox in page.get_texttrace().
 


### PR DESCRIPTION
Add a parameter to "Page.get_get_trace(names=True)" which will cause returning `chr(unicode)` and the name of the glyph instead of the respective integers.

Note: with "rebased", the `extra` version will always be used if `names==True` - as there seems to be no way to correctly invoke  `mupdf.fz_get_glyph_name()` in pure Python.