### PR TITLE
Fixed the bug where `button_states()` returns None when `/AP` points to an indirect object.

### DIFF
--- a/fitz/helper-fields.i
+++ b/fitz/helper-fields.i
@@ -1097,10 +1097,26 @@ class Widget(object):
             for x in apnt:
                 nstates.append(x.split()[0])
             states["normal"] = nstates
+        if APN[0] == "xref":
+            nstates = []
+            nxref = int(APN[1].split(" ")[0])
+            APN = doc.xref_object(nxref)
+            apnt = APN.split("/")[1:]
+            for x in apnt:
+                nstates.append(x.split()[0])
+            states["normal"] = nstates
         APD = doc.xref_get_key(xref, "AP/D")
         if APD[0] == "dict":
             dstates = []
             APD = APD[1][2:-2]
+            apdt = APD.split("/")[1:]
+            for x in apdt:
+                dstates.append(x.split()[0])
+            states["down"] = dstates
+        if APD[0] == "xref":
+            dstates = []
+            dxref = int(APD[1].split(" ")[0])
+            APD = doc.xref_object(dxref)
             apdt = APD.split("/")[1:]
             for x in apdt:
                 dstates.append(x.split()[0])

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6986,10 +6986,26 @@ class Widget:
             for x in apnt:
                 nstates.append(x.split()[0])
             states["normal"] = nstates
+        if APN[0] == "xref":
+            nstates = []
+            nxref = int(APN[1].split(" ")[0])
+            APN = doc.xref_object(nxref)
+            apnt = APN.split("/")[1:]
+            for x in apnt:
+                nstates.append(x.split()[0])
+            states["normal"] = nstates
         APD = doc.xref_get_key(xref, "AP/D")
         if APD[0] == "dict":
             dstates = []
             APD = APD[1][2:-2]
+            apdt = APD.split("/")[1:]
+            for x in apdt:
+                dstates.append(x.split()[0])
+            states["down"] = dstates
+        if APD[0] == "xref":
+            dstates = []
+            dxref = int(APD[1].split(" ")[0])
+            APD = doc.xref_object(dxref)
             apdt = APD.split("/")[1:]
             for x in apdt:
                 dstates.append(x.split()[0])


### PR DESCRIPTION
Description: Some PDF widget objects may not have their `/AP`(Appearance Dictionary) directly pointing to a dictionary, which is enclosed with '<< >>', but rather pointing to an indirect object, expressed by an xref number in the format 'NNN 0 R'. Therefore, the current button_states() only can correctly handle cases where `/AP` points to a dictionary and cannot handle cases where it points to an indirect object. Consequently, I have introduced additional logic to handle the latter scenario, ensuring that `button_states()` can accurately return the on/off state names for button widgets even when `/AP` points to an indirect object.

Test: I have tested the modified `button_states()` function on the mentioned type of PDF, and it now correctly returns the states instead of None.