### PR TITLE
Speedup table extraction

### DIFF
--- a/fitz/table.py
+++ b/fitz/table.py
@@ -1214,7 +1214,11 @@ class Table(object):
             cell = Rect(cell)  # we need a Rect object
             text = ""  # result text
             for block in TEXTPAGE.extractRAWDICT()["blocks"]:
+                if Rect(block["bbox"]).intersect(cell).is_empty:
+                    continue
                 for line in block["lines"]:
+                    if Rect(line["bbox"]).intersect(cell).is_empty:
+                        continue
                     for span in line["spans"]:
                         chars = span["chars"]
                         if text and chars:


### PR DESCRIPTION
Hey there!

I found out that the table extraction can be quite time consuming for big documents and after some profiling I figured out that most of time is spent on `abs` and `__and__` operation between rectangles. Then I realized, that to compute intersection of text with a particular cell, we compare **every** character's bbox at the page with the cell's bbox - which is very ineffective.

As we have bbox for every block and every line, we can quickly invalidate most of the blocks and lines, and skip a lot of expensive comparison operations

I've implemented and tested this quick fix - it gives 10x-20x speedup for my documents

Does this make sense? Maybe I'm missing smth here?