### PR TITLE
Revive Document.subset_fonts

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -5456,8 +5456,8 @@ def subset_fonts(doc: fitz.Document, verbose: bool = False) -> None:
         try:  # invoke fontTools subsetter
             fts.main(args)
             font = fitz.Font(fontfile=newfont_path)
-            new_buffer = font.buffer
-            if len(font.valid_codepoints()) == 0:
+            new_buffer = font.buffer  # subset font binary
+            if font.glyph_count == 0:  # intercept empty font
                 new_buffer = None
         except Exception:
             fitz.exception_info()
@@ -5606,7 +5606,7 @@ def subset_fonts(doc: fitz.Document, verbose: bool = False) -> None:
                 print(f'Cannot subset {fontname!r}.')
             continue
         if verbose:
-            print('Built subset of font {fontname!r}.')
+            print(f"Built subset of font {fontname!r}.")
         val = doc._insert_font(fontbuffer=new_buffer)  # store subset font in PDF
         new_xref = val[0]  # get its xref
         set_subset_fontname(new_xref)  # tag fontname as subset font

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -723,3 +723,23 @@ def test_2736():
     assert text == "CropBox not in MediaBox"
 
 
+def test_subset_fonts():
+    """Confirm subset_fonts is working."""
+    if not hasattr(fitz, "mupdf"):
+        print("Not testing 'test_subset_fonts' in classic.")
+        return
+    text = "Just some arbitrary text."
+    arch = fitz.Archive()
+    css = fitz.css_for_pymupdf_font("ubuntu", archive=arch)
+    css += "* {font-family: ubuntu;}"
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_htmlbox(page.rect, text, css=css, archive=arch)
+    doc.subset_fonts(verbose=True)
+    found = False
+    for xref in range(1, doc.xref_length()):
+        if doc.xref_is_font(xref):
+            if "+Ubuntu#20Regular" in doc.xref_object(xref):
+                found = True
+                break
+    assert found is True


### PR DESCRIPTION
We were assuring that the generated subset font is not empty by counting its Unicodes - which is not yet implemented in rebased. This fix checks the glyph count instead.