### PR TITLE
Ensure valid "re" rectangles

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8673,7 +8673,7 @@ class Page:
                     cmd = item[0]
                     rest = item[1:]
                     if  cmd == "re":
-                        item = ("re", Rect(rest[0]), rest[1])
+                        item = ("re", Rect(rest[0]).normalize(), rest[1])
                     elif cmd == "qu":
                         item = ("qu", Quad(rest[0]))
                     else:
@@ -8807,7 +8807,7 @@ class Page:
                         cmd = item[0]
                         rest = item[1:]
                         if  cmd == "re":
-                            item = ("re", Rect(rest[0]), rest[1])
+                            item = ("re", Rect(rest[0]).normalize(), rest[1])
                         elif cmd == "qu":
                             item = ("qu", Quad(rest[0]))
                         else:

--- a/src_classic/fitz_old.i
+++ b/src_classic/fitz_old.i
@@ -6344,7 +6344,7 @@ def get_oc_items(self) -> list:
                         cmd = item[0]
                         rest = item[1:]
                         if  cmd == "re":
-                            item = ("re", Rect(rest[0]), rest[1])
+                            item = ("re", Rect(rest[0]).normalize(), rest[1])
                         elif cmd == "qu":
                             item = ("qu", Quad(rest[0]))
                         else:
@@ -6479,7 +6479,7 @@ def get_oc_items(self) -> list:
                         cmd = item[0]
                         rest = item[1:]
                         if  cmd == "re":
-                            item = ("re", Rect(rest[0]), rest[1])
+                            item = ("re", Rect(rest[0]).normalize(), rest[1])
                         elif cmd == "qu":
                             item = ("qu", Quad(rest[0]))
                         else:


### PR DESCRIPTION
Derotated pages may cause "re" items to deliver invalid (empty) rectangles, which nonetheless have correct corner points yet a wrong sequence of these points.
We simply ensure valid rects by normalizing them