### PR TITLE
Fix pdf_add_stream metadata error

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5577,7 +5577,7 @@ class Document:
         if xml.m_internal:
             JM_update_stream( pdf, xml, res, 0)
         else:
-            xml = mupdf.pdf_add_stream( pdf, res, None, 0)
+            xml = mupdf.pdf_add_stream( pdf, res, mupdf.PdfObj(), 0)
             mupdf.pdf_dict_put( xml, PDF_NAME('Type'), PDF_NAME('Metadata'))
             mupdf.pdf_dict_put( xml, PDF_NAME('Subtype'), PDF_NAME('XML'))
             mupdf.pdf_dict_put( root, PDF_NAME('Metadata'), xml)


### PR DESCRIPTION
I ran into a problem with the recode_pdf tool from [archive-pdf-tools](https://github.com/internetarchive/archive-pdf-tools), which uses PyMuPDF. This error occurs with versions of PyMuPDF from 1.23.9 and on:

```shell
$ recode_pdf --from-imagestack test001.tif --hocr-file test001.hocr --dpi 400 -o test001.pdf
Traceback (most recent call last):
  File "/home/cody/ocrtest/venv/bin/recode_pdf", line 301, in <module>
    res = recode(args.from_pdf, args.from_imagestack, args.dpi, args.hocr_file,
  File "/home/cody/ocrtest/venv/lib/python3.10/site-packages/internetarchivepdf/recode.py", line 749, in recode
    write_metadata(in_pdf, outdoc, extra_metadata=extra_metadata)
  File "/home/cody/ocrtest/venv/lib/python3.10/site-packages/internetarchivepdf/pdfhacks.py", line 516, in write_metadata
    to_pdf.set_xml_metadata(stream)
  File "/home/cody/ocrtest/venv/lib/python3.10/site-packages/fitz/__init__.py", line 5580, in set_xml_metadata
    xml = mupdf.pdf_add_stream( pdf, res, None, 0)
  File "/home/cody/ocrtest/venv/lib/python3.10/site-packages/fitz/mupdf.py", line 45040, in pdf_add_stream
    return _mupdf.pdf_add_stream(doc, buf, obj, compressed)
ValueError: invalid null reference in method 'pdf_add_stream', argument 3 of type 'mupdf::PdfObj const &'
```

The change in this PR follows the pattern of the other calls to `mupdf.pdf_add_stream` in `src/__init__.py`, but if there's a better way to do it, let me know.