### PR TITLE
Documentation: Updates header-404.rst to use absolute path for search query.

### DIFF
--- a/docs/header-404.rst
+++ b/docs/header-404.rst
@@ -8,11 +8,9 @@
 
 
     <div style="display:flex;justify-content:space-between;align-items: center;">
-        <form class="sidebar-search-container top" method="get" action="search.html" role="search" style="width:100%">
+        <form class="sidebar-search-container top" method="get" action="https://pymupdf.readthedocs.io/en/latest/search.html" role="search" style="width:100%">
           <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
           <input type="hidden" name="check_keywords" value="yes">
           <input type="hidden" name="area" value="default">
         </form>
     </div>
-
-

--- a/docs/header-404.rst
+++ b/docs/header-404.rst
@@ -8,7 +8,7 @@
 
 
     <div style="display:flex;justify-content:space-between;align-items: center;">
-        <form class="sidebar-search-container top" method="get" action="https://pymupdf.readthedocs.io/en/latest/search.html" role="search" style="width:100%">
+        <form class="sidebar-search-container top" method="get" action="/en/latest/search.html" role="search" style="width:100%">
           <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
           <input type="hidden" name="check_keywords" value="yes">
           <input type="hidden" name="area" value="default">


### PR DESCRIPTION
If I do this: https://pymupdf.readthedocs.io/en/1.22.0/about.html and then I think - "okay i'll use Search" then once I use it it will resolve to e.g.: https://pymupdf.readthedocs.io/en/1.22.0/search.html?q=text+extraction&check_keywords=yes&area=default which is also another 404 page as it is stuck on looking in the 1.22.0 path in this case.

This PR fixes the header-404 search to use an absolute path thus resolving the problem.