### PR TITLE
Jules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1060,9 +1060,12 @@ def sdist():
             pass
         else:
             ret.append(p)
-    tgz = get_mupdf_tgz()
-    if tgz:
-        ret.append((tgz, mupdf_tgz))
+    if 0:
+        tgz = get_mupdf_tgz()
+        if tgz:
+            ret.append((tgz, mupdf_tgz))
+    else:
+        log(f'Not including MuPDF .tgz in sdist.')
     return ret
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11917,6 +11917,8 @@ class Story:
 
     def __init__( self, html='', user_css=None, em=12, archive=None):
         buffer_ = mupdf.fz_new_buffer_from_copied_data( html.encode('utf-8'))
+        if archive and not isinstance(archive, Archive):
+            archive = Archive(archive)
         arch = archive.this if archive else mupdf.FzArchive( None)
         if hasattr(mupdf, 'FzStoryS'):
             self.this = mupdf.FzStoryS( buffer_, user_css, em, arch)

--- a/tests/test_story.py
+++ b/tests/test_story.py
@@ -229,3 +229,6 @@ def test_write_stabilized_with_links():
     out_path = __file__.replace('.py', '.pdf')
     document.save(out_path)
     
+def test_archive_creation():
+    s = fitz.Story(archive=fitz.Archive('.'))
+    s = fitz.Story(archive='.')


### PR DESCRIPTION
* setup.py: Only overwrite MuPDF's include/mupdf/fitz/config.h on Windows.
* Fix Story constructor's `archive` arg to match docs.
* setup.py: do not include MuPDF .tgz in sdist to reduce its size.