### PR TITLE
Comment out a debug statement

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2373,7 +2373,6 @@ class Xml:
 
     def span_bottom(self):
         """Find deepest level in stacked spans."""
-        sys.stdout = sys.stderr
         parent = self
         child = self.last_child
         if child is None:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -9630,7 +9630,7 @@ class Pixmap:
             pm = mupdf.fz_new_pixmap(cs, w, h, seps, alpha)
 
             if isinstance( samples, (bytes, bytearray)):
-                log('using mupdf.python_buffer_data()')
+                #log('using mupdf.python_buffer_data()')
                 samples2 = mupdf.python_buffer_data(samples)
                 size = len(samples)
             else:


### PR DESCRIPTION
Comment out a debug statement, so that PyMuPDF does not write to stdout whenever a user initializes a Pixmap object.

Refs #3135
