### PR TITLE
Fixes for clang 18 and new mupdf release branch 1.24.x.

### DIFF
--- a/.github/workflows/test_mupdf-release-branch.yml
+++ b/.github/workflows/test_mupdf-release-branch.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: test_mupdf-release-branch
         env:
-            inputs_PYMUPDF_SETUP_MUPDF_BUILD: "git:--recursive --depth 1 --shallow-submodules --branch 1.23.x https://github.com/ArtifexSoftware/mupdf.git"
+            inputs_PYMUPDF_SETUP_MUPDF_BUILD: "git:--recursive --depth 1 --shallow-submodules --branch 1.24.x https://github.com/ArtifexSoftware/mupdf.git"
             inputs_flavours: "0"
             inputs_sdist: "0"
             inputs_wheels_cps: "cp312*"

--- a/scripts/gh_release.py
+++ b/scripts/gh_release.py
@@ -259,18 +259,29 @@ def build( platform_=None, valgrind=False):
             log(f'Not running cibuildwheel because CIBW_ARCHS_MACOS is empty string.')
             return
     
-    def env_set(name, value, pass_=False):
-        assert isinstance( value, str)
-        if not name.startswith('CIBW'):
-            assert pass_, f'{name=} {value=}'
-        env_extra[ name] = value
-        if pass_ and platform.system() == 'Linux':
+    def env_pass(name):
+        '''
+        Adds `name` to CIBW_ENVIRONMENT_PASS_LINUX if required to be available
+        when building wheel with cibuildwheel.
+        '''
+        if platform.system() == 'Linux':
             v = env_extra.get('CIBW_ENVIRONMENT_PASS_LINUX', '')
             if v:
                 v += ' '
             v += name
             env_extra['CIBW_ENVIRONMENT_PASS_LINUX'] = v
+    
+    def env_set(name, value, pass_=False):
+        assert isinstance( value, str)
+        if not name.startswith('CIBW'):
+            assert pass_, f'{name=} {value=}'
+        env_extra[ name] = value
+        if pass_:
+            env_pass(name)
 
+    if os.environ.get('PYMUPDF_SETUP_LIBCLANG'):
+        env_pass('PYMUPDF_SETUP_LIBCLANG')
+    
     env_set('PYMUPDF_SETUP_IMPLEMENTATIONS', inputs_wheels_implementations, pass_=1)
     if inputs_skeleton:
         env_set('PYMUPDF_SETUP_SKELETON', inputs_skeleton, pass_=1)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -440,6 +440,27 @@ def get_pyproject_required(ppt=None):
         else:
             assert 0, f'Failed to find "requires" line in {ppt}'
 
+def wrap_get_requires_for_build_wheel(dir_):
+    '''
+    Returns space-separated list of required
+    packages. Looks at `dir_`/pyproject.toml and calls
+    `dir_`/setup.py:get_requires_for_build_wheel().
+    '''
+    dir_abs = os.path.abspath(dir_)
+    ret = list()
+    ppt = os.path.join(dir_abs, 'pyproject.toml')
+    if os.path.exists(ppt):
+        ret += get_pyproject_required(ppt)
+    if os.path.exists(os.path.join(dir_abs, 'setup.py')):
+        sys.path.insert(0, dir_abs)
+        try:
+            from setup import get_requires_for_build_wheel as foo
+            for i in foo():
+                ret.append(i)
+        finally:
+            del sys.path[0]
+    return ' '.join(ret)
+
 
 def log(text):
     gh_release.log(text, caller=1)

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ Environmental variables:
             Build wheel called `PyMuPDFb` containing only shared libraries
             that are not specific to a particular Python version - e.g.
             on Linux this will be `libmupdf.so` and `libmupdfcpp.so`.
+    
+    PYMUPDF_SETUP_LIBCLANG
+        For internal testing.
         
     PYMUPDF_SETUP_MUPDF_BUILD
         If set, overrides location of MuPDF when building PyMuPDF:
@@ -1166,7 +1169,11 @@ def get_requires_for_build_wheel(config_settings=None):
     '''
     ret = list()
     ret.append('setuptools')
-    if openbsd:
+    libclang = os.environ.get('PYMUPDF_SETUP_LIBCLANG')
+    if libclang:
+        print(f'Overriding to use {libclang=}.')
+        ret.append(libclang)
+    elif openbsd:
         print(f'OpenBSD: libclang not available via pip; assuming `pkg_add py3-llvm`.')
     elif darwin and platform.machine() == 'arm64':
         print(f'MacOS/arm64: forcing use of libclang 16.0.6 because 18.1.1 known to fail with `clang.cindex.TranslationUnitLoadError: Error parsing translation unit.`')

--- a/src_classic/__init__.py
+++ b/src_classic/__init__.py
@@ -78,20 +78,6 @@ mupdf_version_tuple_required = v_str_to_tuple(fitz_old.VersionFitz)
 mupdf_version_tuple_required_prev = (mupdf_version_tuple_required[0], mupdf_version_tuple_required[1]-1)
 mupdf_version_tuple_required_next = (mupdf_version_tuple_required[0], mupdf_version_tuple_required[1]+1)
 
-if mupdf_version_tuple[:2] not in (
-        mupdf_version_tuple_required_prev[:2],
-        mupdf_version_tuple_required[:2], 
-        mupdf_version_tuple_required_next[:2],
-        ):
-    raise ValueError(
-            f'MuPDF library {v_tuple_to_string(mupdf_version_tuple)!r} mismatch:'
-            f' require'
-            f' {v_tuple_to_string(mupdf_version_tuple_required_prev)!r}'
-            f' or {v_tuple_to_string(mupdf_version_tuple_required)!r}'
-            f' or {v_tuple_to_string(mupdf_version_tuple_required_next)!r}'
-            f'.'
-            )
-
 # copy functions in 'utils' to their respective fitz classes
 import fitz_old.utils
 from .table import find_tables

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -967,6 +967,7 @@ def test_cli_out():
             env['PYMUPDF_LOG'] = log
         if message:
             env['PYMUPDF_MESSAGE'] = message
+        print(f'Running `pymupdf internal`. {env.get("PATH")=}.')
         cp = subprocess.run(f'pymupdf internal', shell=1, check=1, capture_output=1, env=env, text=True)
         
         check_lines(expect_out, cp.stdout)


### PR DESCRIPTION
.github/workflows/test_mupdf-release-branch.yml:
    Use --branch 1.24.x.

scripts/gh_release.py:
    Pass new PYMUPDF_SETUP_LIBCLANG to cibuildwheel build using
    CIBW_ENVIRONMENT_PASS_LINUX.

scripts/sysinstall.py
    Use new setup.py:wrap_get_requires_for_build_wheel() to find
    required packages.

    Disabled tests of `pymupdf` command because doesn't seem to be installed.

scripts/test.py:
    wrap_get_requires_for_build_wheel(): new, uses
    setup.py:get_requires_for_build_wheel() and pyproject.toml to find
    packages, instead of just pyproject.toml.

setup.py:
    Accept PYMUPDF_SETUP_LIBCLANG to specify the version of libclang to
    require. [Not actually used yet, but leaving in place for the future.]

src_classic/__init__.py
    Removed mupdf version checking code, because broken by mupdf 1.25.

tests/test_general.py:
    test_cli_out(): minor diagnostic to show $PATH, used when investigating
    installation of `pymupdf` command with sysinstall.