### PR TITLE
Several fixes for table module

### DIFF
--- a/docs/page.rst
+++ b/docs/page.rst
@@ -419,27 +419,28 @@ In a nutshell, this is what you can do with PyMuPDF:
 
       :returns: a `TableFinder` object that has the following significant attributes:
 
-         * **cells:** a list of **all bboxes** on the page, that have been identified as table cells (across all tables). Each cell is a tuple `(x0, y0, x1, y1)` of coordinates or `None`.
-         * **tables:** a list of `Table` objects. This is `[]` if the page has no tables. Single tables can be found as items of this list. But the `TableFinder` object itself is also a sequence of its tables. This means that if `tabs` is a `TableFinder` object, then table "n" is delivered by `tabs.tables[n]` as well as by the shorter `tabs[n]`.
+         * `cells`: a list of **all bboxes** on the page, that have been identified as table cells (across all tables). Each cell is a :data:`rect_like` tuple `(x0, y0, x1, y1)` of coordinates or `None`.
+         * `tables`: a list of `Table` objects. This is `[]` if the page has no tables. Single tables can be found as items of this list. But the `TableFinder` object itself is also a sequence of its tables. This means that if `tabs` is a `TableFinder` object, then table "n" is delivered by `tabs.tables[n]` as well as by the shorter `tabs[n]`.
 
 
          * The `Table` object has the following attributes:
 
-           * **bbox:** the bounding box of the table as a tuple `(x0, y0, x1, y1)`.
-           * **cells:** bounding boxes of the table's cells (list of tuples). A cell may also be `None`.
-           * **extract():** this method returns the text content of each table cell as a list of list of strings.
-           * **to_pandas():** this method returns the table as a `pandas <https://pypi.org/project/pandas/>`_ `DataFrame <https://pandas.pydata.org/docs/reference/frame.html>`_.
-           * **header:** a `TableHeader` object containing header information of the table.
-           * **col_count:** an integer containing the number of table columns.
-           * **row_count:** an integer containing the number of table rows. 
-           * **rows:** a list of `TableRow` objects containing two attributes: *bbox* is the boundary box of the row, and *cells* is a list of table cells contained in this row.
+           * `bbox`: the bounding box of the table as a tuple `(x0, y0, x1, y1)`.
+           * `cells`: bounding boxes of the table's cells (list of tuples). A cell may also be `None`.
+           * `extract()`: this method returns the text content of each table cell as a list of list of strings.
+           * `to_markdown()`: this method returns the table as a **string in markdown format** (compatible to Github). Supporting viewers can render the string as a table. This output is optimized for **small token** sizes, which is especially beneficial for LLM/RAG feeds. Pandas DataFrames (see method `to_pandas()` below) offer an equivalent markdown table output which however is better readable for the human eye.
+           * `to_pandas()`: this method returns the table as a `pandas <https://pypi.org/project/pandas/>`_ `DataFrame <https://pandas.pydata.org/docs/reference/frame.html>`_. DataFrames are very versatile objects allowing a plethora of table manipulation methods and outputs to almost 20 well-known formats, among them Excel files, CSV, JSON, markdown-formatted tables and more. `DataFrame.to_markdown()` generates a Github-compatible markdown format optimized for human readability. This method however requires the package [tablutate](https://pypi.org/project/tabulate/) to installed in addition to pandas itself.
+           * ``header``: a `TableHeader` object containing header information of the table.
+           * `col_count`: an integer containing the number of table columns.
+           * `row_count`: an integer containing the number of table rows. 
+           * `rows`: a list of `TableRow` objects containing two attributes, ``bbox`` is the boundary box of the row, and `cells` is a list of table cells contained in this row.
 
          * The `TableHeader` object has the following attributes:
 
-           * **bbox:** the bounding box of the header.
-           * **cells:** a list of bounding boxes containing the name of the respective column.
-           * **names:** a list of strings containing the text of each of the cell bboxes. They represent the column names -- which can be used when exporting the table to pandas DataFrames or CSV, etc.
-           * **external:** a bool indicating whether the header bbox is outside the table body (`True`) or not. Table headers are never identified by the `TableFinder` logic. Therefore, if *external* is true, then the header cells are not part of any cell identified by `TableFinder`. If `external == False`, then the first table row is the header.
+           * ``bbox``: the bounding box of the header.
+           * `cells`: a list of bounding boxes containing the name of the respective column.
+           * `names`: a list of strings containing the text of each of the cell bboxes. They represent the column names -- which are used when exporting the table to pandas DataFrames, markdown, etc.
+           * `external`: a bool indicating whether the header bbox is outside the table body (`True`) or not. Table headers are never identified by the `TableFinder` logic. Therefore, if `external` is true, then the header cells are not part of any cell identified by `TableFinder`. If `external == False`, then the first table row is the header.
 
          Please have a look at these `Jupyter notebooks <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/table-analysis>`_, which cover standard situations like multiple tables on one page or joining table fragments across multiple pages.
 


### PR DESCRIPTION
- Add new method for outputting the table as a markdown string.

- Address errors in computing the table header object: We now allow None as the cell value, because this will be resolved where needed (e.g. in the pandas DataFrame).

We previously tried to enforce rect-like tuples in all header cell bboxes, however this fails for tables with all-None columns. This fix enables this and constructs an empty string in the corresponding cell string.

We now correctly include start / stop points of lines in the bbox of the clustered graphic. We previously joined the line's rectangle - which had no effect because this is always empty.