### PR TITLE
Support ObjStm Compression

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4022,6 +4022,9 @@ class Document:
             owner_pw=None,
             user_pw=None,
             no_new_id=True,
+            preserve_metadata=1,
+            use_objstms=1,
+            compression_effort=0,
             ):
         '''
         Save PDF using some different defaults
@@ -4043,6 +4046,9 @@ class Document:
                 owner_pw=owner_pw,
                 user_pw=user_pw,
                 no_new_id=no_new_id,
+                preserve_metadata=preserve_metadata,
+                use_objstms=use_objstms,
+                compression_effort=compression_effort,
                 )
 
     def find_bookmark(self, bm):
@@ -5312,6 +5318,9 @@ class Document:
             permissions=4095,
             owner_pw=None,
             user_pw=None,
+            preserve_metadata=1,
+            use_objstms=0,
+            compression_effort=0,
             ):
         # From %pythonprepend save
         #
@@ -5338,27 +5347,30 @@ class Document:
         
         pdf = _as_pdf_document(self)
         opts = mupdf.PdfWriteOptions()
-        opts.do_incremental     = incremental
-        opts.do_ascii           = ascii
-        opts.do_compress        = deflate
+        opts.do_incremental = incremental
+        opts.do_ascii = ascii
+        opts.do_compress = deflate
         opts.do_compress_images = deflate_images
-        opts.do_compress_fonts  = deflate_fonts
-        opts.do_decompress      = expand
-        opts.do_garbage         = garbage
-        opts.do_pretty          = pretty
-        opts.do_linear          = linear
-        opts.do_clean           = clean
-        opts.do_sanitize        = clean
+        opts.do_compress_fonts = deflate_fonts
+        opts.do_decompress = expand
+        opts.do_garbage = garbage
+        opts.do_pretty = pretty
+        opts.do_linear = linear
+        opts.do_clean = clean
+        opts.do_sanitize = clean
         opts.dont_regenerate_id = no_new_id
-        opts.do_appearance      = appearance
-        opts.do_encrypt         = encryption
-        opts.permissions        = permissions
+        opts.do_appearance = appearance
+        opts.do_encrypt = encryption
+        opts.permissions = permissions
         if owner_pw is not None:
             opts.opwd_utf8_set_value(owner_pw)
         elif user_pw is not None:
             opts.opwd_utf8_set_value(user_pw)
         if user_pw is not None:
             opts.upwd_utf8_set_value(user_pw)
+        opts.do_preserve_metadata = preserve_metadata
+        opts.do_use_objstms = use_objstms
+        opts.compression_effort = compression_effort
 
         out = None
         ASSERT_PDF(pdf)
@@ -5409,7 +5421,7 @@ class Document:
         if (len(pyliste) == 0
             or min(pyliste) not in valid_range
             or max(pyliste) not in valid_range
-           ):
+        ):
             raise ValueError("bad page number(s)")
 
         # get underlying pdf document,
@@ -5671,8 +5683,11 @@ class Document:
             encryption=1,
             permissions=4095,
             owner_pw=None,
-            user_pw=None
-            ):
+            user_pw=None,
+            preserve_metadata=1,
+            use_objstms=0,
+            compression_effort=0,
+    ):
         from io import BytesIO
         bio = BytesIO()
         self.save(
@@ -5693,7 +5708,10 @@ class Document:
                 permissions=permissions,
                 owner_pw=owner_pw,
                 user_pw=user_pw,
-                )
+                preserve_metadata=preserve_metadata,
+                use_objstms=use_objstms,
+                compression_effort=compression_effort,
+        )
         return bio.getvalue()
 
     @property

--- a/tests/test_objectstreams.py
+++ b/tests/test_objectstreams.py
@@ -1,0 +1,83 @@
+import fitz
+
+
+def test_objectstream1():
+    """Test save option "use_objstms".
+    This option compresses PDF object definitions into a special object type
+    "ObjStm". We test its presence by searching for that /Type.
+    """
+    if not hasattr(fitz, "mupdf"):
+        # only implemented for rebased
+        return
+
+    # make some arbitrary page with content
+    text = "Hello, World! Hallo, Welt!"
+    doc = fitz.open()
+    page = doc.new_page()
+    rect = (50, 50, 200, 500)
+
+    page.insert_htmlbox(rect, text)  # place into the rectangle
+    _ = doc.write(use_objstms=True)
+    found = False
+    for xref in range(1, doc.xref_length()):
+        objstring = doc.xref_object(xref, compressed=True)
+        if "/Type/ObjStm" in objstring:
+            found = True
+            break
+    assert found, "No object stream found"
+
+
+def test_objectstream2():
+    """Test save option "use_objstms".
+    This option compresses PDF object definitions into a special object type
+    "ObjStm". We test its presence by searching for that /Type.
+    """
+    if not hasattr(fitz, "mupdf"):
+        # only implemented for rebased
+        return
+
+    # make some arbitrary page with content
+    text = "Hello, World! Hallo, Welt!"
+    doc = fitz.open()
+    page = doc.new_page()
+    rect = (50, 50, 200, 500)
+
+    page.insert_htmlbox(rect, text)  # place into the rectangle
+    _ = doc.write(use_objstms=False)
+
+    found = False
+    for xref in range(1, doc.xref_length()):
+        objstring = doc.xref_object(xref, compressed=True)
+        if "/Type/ObjStm" in objstring:
+            found = True
+            break
+    assert not found, "Unexpected: Object stream found!"
+
+
+def test_objectstream3():
+    """Test ez_save().
+    Should automatically use object streams
+    """
+    if not hasattr(fitz, "mupdf"):
+        # only implemented for rebased
+        return
+    import io
+
+    fp = io.BytesIO()
+
+    # make some arbitrary page with content
+    text = "Hello, World! Hallo, Welt!"
+    doc = fitz.open()
+    page = doc.new_page()
+    rect = (50, 50, 200, 500)
+
+    page.insert_htmlbox(rect, text)  # place into the rectangle
+
+    doc.ez_save(fp)  # save PDF to memory
+    found = False
+    for xref in range(1, doc.xref_length()):
+        objstring = doc.xref_object(xref, compressed=True)
+        if "/Type/ObjStm" in objstring:
+            found = True
+            break
+    assert found, "No object stream found!"


### PR DESCRIPTION
Methods Document.save(), Document.ez_save() and  Document.write() now support new parameters:
* use_objstms
* compression_effort
* preserve_metadata

ObjStm support means the optional creation of PDF object type /ObjStm objects. These are stream objects capable of containing eligible other object definitions of the PDF within their stream. In this way, the object definitions inside the ObjStm stream become compressible - which may result in considerable PDF size reductions compared to only compressing images and fonts. To benefit from file size reductions, save option "deflate" must not be zero (resp. False). The default of method Document.ez_save() now includes "use_objstms=1" to automatically benefit from the extended compression effect.

New tests are used to confirm the presence, respectively absence of /ObjStm object types as requested.

Parameters "compression_effort" and "preserve_metadata" are simply handed over to MuPDF. We currently have no way to validate their effects.