### PR TITLE
Add Page method "cluster_drawings"

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7651,10 +7651,11 @@ class Page:
         JM_add_annot_id(annot, "W")
         return Annot(annot)
 
-    def _apply_redactions(self, images, graphics):
+    def _apply_redactions(self, text, images, graphics):
         page = self._pdf_page()
         opts = mupdf.PdfRedactOptions()
         opts.black_boxes = 0  # no black boxes
+        opts.text = text  # how to treat text
         opts.image_method = images  # how to treat images
         opts.line_art = graphics  # how to treat vector graphics
         ASSERT_PDF(page)
@@ -8922,6 +8923,102 @@ class Page:
 
             val = None
             return paths
+
+    def cluster_drawings(
+        self, clip=None, drawings=None, x_tolerance: float = 3, y_tolerance: float = 3
+    ) -> list:
+        """Join rectangles of neighboring vector graphic items.
+
+        Args:
+            clip: optional rect-like to restrict the page area to consider.
+            drawings: (optional) output of a previous "get_drawings()".
+            x_tolerance: horizontal neighborhood threshold.
+            y_tolerance: vertical neighborhood threshold.
+
+        Notes:
+            Vector graphics (also called line-art or drawings) usually consist
+            of independent items like rectangles, lines or curves to jointly
+            form table grid lines or bar, line, pie charts and similar.
+            This method identifies rectangles wrapping these disparate items.
+
+        Returns:
+            A list of Rect items, each wrapping line-art items that are close
+            enough to be considered forming a common vector graphic.
+            Only "significant" rectangles will be returned, i.e. having both,
+            width and height larger than the tolerance values.
+        """
+        CheckParent(self)
+        parea = self.rect  # the default clipping area
+        if clip is not None:
+            parea = Rect(clip)
+        delta_x = x_tolerance  # shorter local name
+        delta_y = y_tolerance  # shorter local name
+        if drawings is None:  # if we cannot re-use a previous output
+            drawings = self.get_drawings()
+
+        def are_neighbors(r1, r2):
+            """Detect whether r1, r2 are "neighbors".
+
+            Items r1, r2 are called neighbors if the minimum distance between
+            their points is less-equal delta.
+
+            Both parameters must be (potentially invalid) rectangles.
+            """
+            # normalize rectangles as needed
+            rr1_x0, rr1_x1 = (r1.x0, r1.x1) if r1.x1 > r1.x0 else (r1.x1, r1.x0)
+            rr1_y0, rr1_y1 = (r1.y0, r1.y1) if r1.y1 > r1.y0 else (r1.y1, r1.y0)
+            rr2_x0, rr2_x1 = (r2.x0, r2.x1) if r2.x1 > r2.x0 else (r2.x1, r2.x0)
+            rr2_y0, rr2_y1 = (r2.y0, r2.y1) if r2.y1 > r2.y0 else (r2.y1, r2.y0)
+            if (
+                0
+                or rr1_x1 < rr2_x0 - delta_x
+                or rr1_x0 > rr2_x1 + delta_x
+                or rr1_y1 < rr2_y0 - delta_y
+                or rr1_y0 > rr2_y1 + delta_y
+            ):
+                # Rects do not overlap.
+                return False
+            else:
+                # Rects overlap.
+                return True
+
+        # exclude graphics not contained in the clip
+        paths = [
+            p
+            for p in drawings
+            if 1
+            and p["rect"].x0 >= parea.x0
+            and p["rect"].x1 <= parea.x1
+            and p["rect"].y0 >= parea.y0
+            and p["rect"].y1 <= parea.y1
+        ]
+
+        # list of all vector graphic rectangles
+        prects = sorted([p["rect"] for p in paths], key=lambda r: (r.y1, r.x0))
+
+        new_rects = []  # the final list of the joined rectangles
+
+        # -------------------------------------------------------------------------
+        # The strategy is to identify and join all rects that are neighbors
+        # -------------------------------------------------------------------------
+        while prects:  # the algorithm will empty this list
+            r = +prects[0]  # copy of first rectangle
+            repeat = True
+            while repeat:
+                repeat = False
+                for i in range(len(prects) - 1, 0, -1):  # from back to front
+                    if are_neighbors(prects[i], r):
+                        r |= prects[i].tl  # include in first rect
+                        r |= prects[i].br  # include in first rect
+                        del prects[i]  # delete this rect
+                        repeat = True
+
+            new_rects.append(r)
+            del prects[0]
+            prects = sorted(set(prects), key=lambda r: (r.y1, r.x0))
+
+        new_rects = sorted(set(new_rects), key=lambda r: (r.y1, r.x0))
+        return [r for r in new_rects if r.width > delta_x and r.height > delta_y]
 
     def get_fonts(self, full=False):
         """List of fonts defined in the page object."""

--- a/tests/test_cluster_drawings.py
+++ b/tests/test_cluster_drawings.py
@@ -1,0 +1,47 @@
+import os
+import fitz
+
+scriptdir = os.path.dirname(__file__)
+
+
+def test_cluster1():
+    """Confirm correct identification of known examples."""
+    if not hasattr(fitz, "mupdf"):
+        print("Not executing 'test_cluster1' in classic")
+        return
+    filename = os.path.join(scriptdir, "resources", "symbol-list.pdf")
+    doc = fitz.open(filename)
+    page = doc[0]
+    assert len(page.cluster_drawings()) == 10
+    filename = os.path.join(scriptdir, "resources", "chinese-tables.pdf")
+    doc = fitz.open(filename)
+    page = doc[0]
+    assert len(page.cluster_drawings()) == 2
+
+
+def test_cluster2():
+    """Join disjoint but neighbored drawings."""
+    if not hasattr(fitz, "mupdf"):
+        print("Not executing 'test_cluster2' in classic")
+        return
+    doc = fitz.open()
+    page = doc.new_page()
+    r1 = fitz.Rect(100, 100, 200, 200)
+    r2 = fitz.Rect(203, 203, 400, 400)
+    page.draw_rect(r1)
+    page.draw_rect(r2)
+    assert page.cluster_drawings() == [r1 | r2]
+
+
+def test_cluster3():
+    """Confirm as separate if neighborhood threshold exceeded."""
+    if not hasattr(fitz, "mupdf"):
+        print("Not executing 'test_cluster3' in classic")
+        return
+    doc = fitz.open()
+    page = doc.new_page()
+    r1 = fitz.Rect(100, 100, 200, 200)
+    r2 = fitz.Rect(204, 200, 400, 400)
+    page.draw_rect(r1)
+    page.draw_rect(r2)
+    assert page.cluster_drawings() == [r1, r2]


### PR DESCRIPTION
New method "Page.cluster_drawings" identifies drawing items (i.e. vector graphics or line-art) that belong together based on their geometrical vicinity and computes rectangles that wrap such "clusters".

Another change adds a new parameter "keep_text" to `Page.apply_redactions()` to reflect MuPDF's capability to independently keep or remove the three object categories text, images and vector graphics during applying redactions.