### PR TITLE
fix test_mupdf_regressions version check for bug 707727

### DIFF
--- a/tests/test_mupdf_regressions.py
+++ b/tests/test_mupdf_regressions.py
@@ -50,7 +50,7 @@ def test_707727():
     page = doc.reload_page(page)  # required to prevent re-use
     pix1 = page.get_pixmap()
     ok = pix0.samples == pix1.samples
-    if fitz.mupdf_version_tuple >= (1, 24, 1):
+    if fitz.mupdf_version_tuple > (1, 24, 1):
         assert ok
     else:
         assert not ok


### PR DESCRIPTION
Bug 707727 is fixed in mupdf's master branch, not in the release branch and in particular not in 1.24.1. So adjust the check, assuming that the fix will be backported to 1.24.2

Depending on your plans for the backports, the version check needs be adjusted, of course. The proposed change is the minimal change which works as of today.