### PR TITLE
Stabilize q-count

### DIFF
--- a/tests/test_balance_count.py
+++ b/tests/test_balance_count.py
@@ -18,11 +18,20 @@ def test_q_count():
     assert page._count_q_balance() == (1, 0)
     assert page.is_wrapped is False
 
+    # Prepend more data that yield a different type of imbalanced contents:
+    # Although counts of q and Q are equal now, the unshielded 'cm' before
+    # the first 'q' makes the contents unusable for insertions.
+    fitz.TOOLS._insert_contents(page, b"1 0 0 -1 0 0 cm q ", False)  # prepend
+    assert page.is_wrapped is False
+    if page._count_q_balance() == (0, 0):
+        print("imbalance undetected by q balance count")
+
     text = "Hello, World!"
     page.insert_text((100, 100), text)  # establishes balance!
 
     # this should have produced a balanced graphics state
     assert page._count_q_balance() == (0, 0)
+    assert page.is_wrapped
 
     # an appended "pop" must be balanced by a prepended "push"
     fitz.TOOLS._insert_contents(page, b"Q", True)  # append


### PR DESCRIPTION
MuPDF's function `pdf_count_q_balance()` does not yet cover all cases. This fix adds a check to also cover corner cases.