### PR TITLE
.github/workflows/build_wheels.yml: use macos-13 and macos-14.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,9 +29,9 @@ on:
         type: boolean
         default: true
         
-      wheels_macos_arm64:
-        type: boolean
-        default: true
+      #wheels_macos_arm64:
+      #  type: boolean
+      #  default: true
       
       wheels_macos_auto:
         type: boolean
@@ -78,7 +78,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        # 2024-05-08: Need to specify macos-13/14 to get x86_64/arm64.
+        os: [ubuntu-latest, windows-2019, macos-13, macos-14]
 
       # Avoid cancelling of all cibuildwheel runs after a single failure.
       fail-fast: false
@@ -132,7 +133,7 @@ jobs:
             inputs_wheels_linux_aarch64: ${{inputs.wheels_linux_aarch64}}
             inputs_wheels_linux_auto: ${{inputs.wheels_linux_auto}}
             inputs_wheels_linux_pyodide: ${{inputs.wheels_linux_pyodide}}
-            inputs_wheels_macos_arm64: ${{inputs.wheels_macos_arm64}}
+            #inputs_wheels_macos_arm64: ${{inputs.wheels_macos_arm64}}
             inputs_wheels_macos_auto: ${{inputs.wheels_macos_auto}}
             inputs_wheels_windows_auto: ${{inputs.wheels_windows_auto}}
             


### PR DESCRIPTION
This fixes generation of MacOS x86/arm64 wheels.

Actually macos-13 appears to build both x86_64 and arm64 wheels, presumably the latter using cross-compilation; these arm64 wheels appear to be the ones that appear in the final artifact (maybe because they are created later).

But macos-13 does not run pytest on the arm64 wheels, so we continue to also build on macos-14.