### PR TITLE
Fontsubset docs

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -5360,7 +5360,7 @@ def recover_char_quad(line_dir: tuple, span: dict, char: dict) -> pymupdf.Quad:
 # Building font subsets using fontTools
 # -------------------------------------------------------------------
 def subset_fonts(doc: pymupdf.Document, verbose: bool = False, fallback: bool = False) -> None:
-    """Build font subsets of a PDF. Requires package 'fontTools'.
+    """Build font subsets in a PDF.
 
     Eligible fonts are potentially replaced by smaller versions. Page text is
     NOT rewritten and thus should retain properties like being hidden or
@@ -5369,6 +5369,7 @@ def subset_fonts(doc: pymupdf.Document, verbose: bool = False, fallback: bool = 
     This method by default uses MuPDF's own internal feature to create subset
     fonts. As this is a new function, errors may still occur. In this case,
     please fall back to using the previous version by using "fallback=True".
+    Fallback mode requires the external package 'fontTools'.
     """
     # Font binaries: -  "buffer" -> (names, xrefs, (unicodes, glyphs))
     # An embedded font is uniquely defined by its fontbuffer only. It may have

--- a/src/utils.py
+++ b/src/utils.py
@@ -5359,7 +5359,7 @@ def recover_char_quad(line_dir: tuple, span: dict, char: dict) -> pymupdf.Quad:
 # -------------------------------------------------------------------
 # Building font subsets using fontTools
 # -------------------------------------------------------------------
-def subset_fonts(doc: pymupdf.Document, verbose: bool = False, fallback: bool = False) -> None:
+def subset_fonts(doc: pymupdf.Document, verbose: bool = False, fallback: bool = False) -> OptInt:
     """Build font subsets in a PDF.
 
     Eligible fonts are potentially replaced by smaller versions. Page text is
@@ -5370,6 +5370,16 @@ def subset_fonts(doc: pymupdf.Document, verbose: bool = False, fallback: bool = 
     fonts. As this is a new function, errors may still occur. In this case,
     please fall back to using the previous version by using "fallback=True".
     Fallback mode requires the external package 'fontTools'.
+
+    Args:
+        fallback: use the older deprecated implementation.
+        verbose: only used by fallback mode.
+
+    Returns:
+        The new MuPDF-based code returns None.  The deprecated fallback
+        mode returns 0 if there are no fonts to subset.  Otherwise, it
+        returns the decrease in fontsize (the difference in fontsize),
+        measured in bytes.
     """
     # Font binaries: -  "buffer" -> (names, xrefs, (unicodes, glyphs))
     # An embedded font is uniquely defined by its fontbuffer only. It may have


### PR DESCRIPTION
The return type is different b/w the new way and the deprecated implementation.  Also, `verbose` only does something for the old code.  `fontTools` is needed only for the deprecated implementation.
