### PR TITLE
Fixed utils.do_links() crash.

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1533,7 +1533,7 @@ def do_links(
                 pnt = lnk.get("to", pymupdf.Point(0, 0))  # destination point
                 if type(pnt) is not pymupdf.Point:
                     pnt = pymupdf.Point(0, 0)
-                annot = txt % (
+                annot = txt(
                     lnk["page"],
                     pnt.x,
                     pnt.y,


### PR DESCRIPTION
Follow up to 2067826105c58c68942839aed95ae4e7909ee341.
Regression in bde7550154daad82ff7e346f033e78caf2784159.

Refs #3471.