### PR TITLE
.github/workflows/test_pyodide.yml: default to hard-coded mupdf, not …

### DIFF
--- a/.github/workflows/test_pyodide.yml
+++ b/.github/workflows/test_pyodide.yml
@@ -2,6 +2,12 @@ name: Build Pyodide wheel
 
 on:
   workflow_dispatch:
+  
+    inputs:
+      PYMUPDF_SETUP_MUPDF_BUILD:
+          description: 'Value for PYMUPDF_SETUP_MUPDF_BUILD, e.g.: git:--branch master https://github.com/ArtifexSoftware/mupdf.git'
+          type: string
+
   schedule:
     - cron: '13 5 * * *'
 
@@ -32,7 +38,7 @@ jobs:
       - name: build_pyodide_wheel
         env:
             inputs_sdist: 0
-            inputs_PYMUPDF_SETUP_MUPDF_BUILD: "git:--recursive --depth 1 --shallow-submodules --branch master https://github.com/ArtifexSoftware/mupdf.git"
+            inputs_PYMUPDF_SETUP_MUPDF_BUILD: ${{inputs.PYMUPDF_SETUP_MUPDF_BUILD}}
             inputs_wheels_default: 0
             inputs_wheels_linux_pyodide: 1
             inputs_wheels_implementations: b


### PR DESCRIPTION
…master.

This will allow us to also build Pyodide wheels when we make a release.