### PR TITLE
.github/workflows/test_pyodide.yml: use mupdf master instead of hard-…

### DIFF
--- a/.github/workflows/test_pyodide.yml
+++ b/.github/workflows/test_pyodide.yml
@@ -7,6 +7,7 @@ on:
       PYMUPDF_SETUP_MUPDF_BUILD:
           description: 'Value for PYMUPDF_SETUP_MUPDF_BUILD, e.g.: git:--branch master https://github.com/ArtifexSoftware/mupdf.git'
           type: string
+          default: 'git:--branch master https://github.com/ArtifexSoftware/mupdf.git'
 
   schedule:
     - cron: '13 5 * * *'


### PR DESCRIPTION
…coded mupdf.

It's more useful to check for regressions with MuPDF master.