### PR TITLE
Update Document to check the /XYZ len

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5305,7 +5305,11 @@ class Document:
             if array.startswith("/XYZ"):
                 del templ_dict["dest"]  # don't return orig string in this case
                 arr_t = array.split()[1:]
-                x, y, z = tuple(map(float, arr_t))
+                if len(arr_t) == 3:
+                    x, y, z = tuple(map(float, arr_t))
+                else:
+                    x, y = tuple(map(float, arr_t))
+                    z = 0
                 templ_dict["to"] = (x, y)
                 templ_dict["zoom"] = z
 


### PR DESCRIPTION
The issue arises because some PDFs return `/XYZ` coordinates in the format `/XYZ x y` instead of `/XYZ x y z`. This discrepancy causes the code to fail when attempting to unpack three values from an array that only contains two.