### PR TITLE
setup.py: fix generation of mupdf header tree.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -626,10 +626,16 @@ def build():
                 add('b', pipcl.get_soname(f'{mupdf_build_dir}/libmupdf.so'), to_dir)
             
             if 'd' in PYMUPDF_SETUP_FLAVOUR:
-                # Add MuPDF headers to `ret_d`.
+                # Add MuPDF headers to `ret_d`. Would prefer to use
+                # pipcl.git_items() but hard-coded mupdf tree is not a git
+                # checkout.
                 include = f'{mupdf_local}/include'
-                for header in pipcl.git_items(include):
-                    add('d', f'{include}/{header}', f'{to_dir_d}/include/{header}')
+                for dirpath, dirnames, filenames in os.walk(include):
+                    for filename in filenames:
+                        header_abs = os.path.join(dirpath, filename)
+                        assert header_abs.startswith(include)
+                        header_rel = header_abs[len(include)+1:]
+                        add('d', f'{header_abs}', f'{to_dir_d}/include/{header_rel}')
         
         # Add a .py file containing location of MuPDF.
         text = f"mupdf_location='{mupdf_location}'\n"


### PR DESCRIPTION
We cannot use `git ls-files` when building using the hard-coded MuPDF default release because it is not a git checkout.