### PR TITLE
src/__init__.py: fix to work with latest mupdf 1.24.8.

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2818,7 +2818,7 @@ class Document:
                                         stream = mupdf.FzStream(filename)
                                         accel = mupdf.FzStream()
                                         archive = mupdf.FzArchive(None)
-                                        if mupdf_version_tuple >= (1, 25):
+                                        if mupdf_version_tuple >= (1, 24, 8):
                                             doc = mupdf.ll_fz_document_handler_open(
                                                     handler,
                                                     stream.m_internal,


### PR DESCRIPTION
Commit d4e216ceea46f1b39e591c41adc7e506db07e29c updated the fns to call fz_document_handler fnprts and they have now been backported to the 1.24.x branch so here we accommodate for that.