### PR TITLE
Jules - various

### DIFF
--- a/.github/workflows/test_pyodide.yml
+++ b/.github/workflows/test_pyodide.yml
@@ -42,7 +42,6 @@ jobs:
             inputs_PYMUPDF_SETUP_MUPDF_BUILD: ${{inputs.PYMUPDF_SETUP_MUPDF_BUILD}}
             inputs_wheels_default: 0
             inputs_wheels_linux_pyodide: 1
-            inputs_wheels_implementations: b
         run:
           python scripts/gh_release.py build
 

--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -48,10 +48,6 @@ General steps
     *
       `CFLAGS`, `CXXFLAGS` and `LDFLAGS` set to allow visibility of the
       installed MuPDF headers and shared libraries.
-    *
-      [As of 2024-04-15, tere is no need to set
-      `PYMUPDF_SETUP_IMPLEMENTATIONS=b` to build only the rebased
-      implementation, as this is now the default.]
 
 * Run PyMuPDF tests:
 

--- a/docs/pymupdf4llm/api.rst
+++ b/docs/pymupdf4llm/api.rst
@@ -33,7 +33,7 @@ The |PyMuPDF4LLM| API
 
         - **"metadata"** - a dictionary consisting of the document's metadata `Document.metadata <https://pymupdf.readthedocs.io/en/latest/document.html#Document.metadata>`_, enriched with additional keys **"file_path"** (the file name), **"page_count"** (number of pages in document), and **"page_number"** (1-based page number).
 
-        - **"toc_items"** - a list of Table of Contents items pointing to this page. Each item of this list has the format `[lvl, title, pagenumber]`, where `lvl` is the hierachy level, `title` a string and `pagenumber` the 12-based page number.
+        - **"toc_items"** - a list of Table of Contents items pointing to this page. Each item of this list has the format `[lvl, title, pagenumber]`, where `lvl` is the hierarchy level, `title` a string and `pagenumber` the 12-based page number.
 
         - **"tables"** - a list of tables on this page. Each item is a dictionary with keys "bbox", "row_count" and "col_count". Key "bbox" is a `pymupdf.Rect` in tuple format of the table's position on the page.
 

--- a/docs/pyodide.rst
+++ b/docs/pyodide.rst
@@ -28,7 +28,6 @@ directory set to a PyMuPDF checkout), that builds a Pyodide wheel::
     inputs_PYMUPDF_SETUP_MUPDF_BUILD="git:--recursive --depth 1 --shallow-submodules --branch master https://github.com/ArtifexSoftware/mupdf.git" \
     inputs_wheels_default=0 \
     inputs_wheels_linux_pyodide=1 \
-    inputs_wheels_implementations=b \
     ./scripts/gh_release.py build
 
 This does the following (all inside Python venv's):

--- a/scripts/gh_release.py
+++ b/scripts/gh_release.py
@@ -370,8 +370,8 @@ def build( platform_=None, valgrind=False):
     
         run('pip install cibuildwheel')
     
-        # We include MuPDF build-time files on certain platforms.
-        flavour_d = platform.system() in ('Linux', 'Windows') and cpu_bits() == 64
+        # We include MuPDF build-time files.
+        flavour_d = True
         
         if inputs_flavours:
             # Build and test PyMuPDF and PyMuPDFb wheels.

--- a/scripts/gh_release.py
+++ b/scripts/gh_release.py
@@ -53,9 +53,6 @@ action inputs, which can't be easily translated into command-line arguments.
         E.g. 'git:--recursive --depth 1 --shallow-submodules --branch master https://github.com/ArtifexSoftware/mupdf.git'
     inputs_PYMUPDF_SETUP_MUPDF_BUILD_TYPE
         Used to directly set PYMUPDF_SETUP_MUPDF_BUILD_TYPE.
-    inputs_wheels_implementations
-        Used to directly set PYMUPDF_SETUP_IMPLEMENTATIONS.
-        'a', 'b', 'ab'.
 
 Building for Pyodide
 
@@ -194,7 +191,6 @@ def build( platform_=None, valgrind=False):
     inputs_wheels_cps = os.environ.get('inputs_wheels_cps')
     inputs_PYMUPDF_SETUP_MUPDF_BUILD = os.environ.get('inputs_PYMUPDF_SETUP_MUPDF_BUILD')
     inputs_PYMUPDF_SETUP_MUPDF_BUILD_TYPE = os.environ.get('inputs_PYMUPDF_SETUP_MUPDF_BUILD_TYPE')
-    inputs_wheels_implementations = os.environ.get('inputs_wheels_implementations', 'b')
     
     log( f'{inputs_flavours=}')
     log( f'{inputs_sdist=}')
@@ -221,7 +217,7 @@ def build( platform_=None, valgrind=False):
                 log(f'Overriding inputs_PYMUPDF_SETUP_MUPDF_BUILD because {GITHUB_EVENT_NAME=} {inputs_PYMUPDF_SETUP_MUPDF_BUILD=}.')
                 inputs_PYMUPDF_SETUP_MUPDF_BUILD = 'git:--branch master https://github.com/ArtifexSoftware/mupdf.git'
                 log(f'{inputs_PYMUPDF_SETUP_MUPDF_BUILD=}')
-        build_pyodide_wheel(inputs_wheels_implementations, inputs_PYMUPDF_SETUP_MUPDF_BUILD)
+        build_pyodide_wheel(inputs_PYMUPDF_SETUP_MUPDF_BUILD)
     
     # Build sdist(s).
     #
@@ -349,7 +345,6 @@ def build( platform_=None, valgrind=False):
         if os.environ.get('PYMUPDF_SETUP_LIBCLANG'):
             env_pass('PYMUPDF_SETUP_LIBCLANG')
     
-        env_set('PYMUPDF_SETUP_IMPLEMENTATIONS', inputs_wheels_implementations, pass_=1)
         if inputs_skeleton:
             env_set('PYMUPDF_SETUP_SKELETON', inputs_skeleton, pass_=1)
     
@@ -440,7 +435,7 @@ def build( platform_=None, valgrind=False):
         run( 'ls -lt wheelhouse')
 
 
-def build_pyodide_wheel( implementations, inputs_PYMUPDF_SETUP_MUPDF_BUILD):
+def build_pyodide_wheel(inputs_PYMUPDF_SETUP_MUPDF_BUILD):
     '''
     Build Pyodide wheel.
 
@@ -465,8 +460,6 @@ def build_pyodide_wheel( implementations, inputs_PYMUPDF_SETUP_MUPDF_BUILD):
     # Tell MuPDF to build for Pyodide.
     env_extra['OS'] = 'pyodide'
 
-    env_extra['PYMUPDF_SETUP_IMPLEMENTATIONS'] = implementations
-    
     # Build a single wheel without a separate PyMuPDFb wheel.
     env_extra['PYMUPDF_SETUP_FLAVOUR'] = 'pb'
     

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -50,7 +50,6 @@ Options:
     -i <implementations>
         Set PyMuPDF implementations to test.
         <implementations> must contain only these individual characters:
-             'c' - classic.
              'r' - rebased.
              'R' - rebased without optimisations.
             Default is 'rR'. Also see `PyMuPDF:tests/run_compound.py`.
@@ -235,7 +234,6 @@ def main(argv):
 
     def do_build(wheel=False):
         build(
-                implementations=implementations,
                 build_type=build_type,
                 build_isolation=build_isolation,
                 venv_quick=venv_quick,
@@ -321,7 +319,6 @@ def venv_info(pytest_args=None):
 
 
 def build(
-        implementations=None,
         build_type=None,
         build_isolation=None,
         venv_quick=False,
@@ -368,13 +365,6 @@ def build(
         build_isolation_text = ' --no-build-isolation'
     
     env_extra = dict()
-    if implementations:
-        v = ''
-        if 'c' in implementations:
-            v += 'a'
-        if 'r' in implementations or 'R' in implementations:
-            v += 'b'
-        env_extra['PYMUPDF_SETUP_IMPLEMENTATIONS'] = v
     if not build_mupdf:
         env_extra['PYMUPDF_SETUP_MUPDF_REBUILD'] = '0'
     if build_type:

--- a/tests/run_compound.py
+++ b/tests/run_compound.py
@@ -7,17 +7,13 @@ Runs a command using different implementations of PyMuPDF:
 
 2.  As 1 but also set PYMUPDF_USE_EXTRA=0 to disable use of C++ optimisations.
 
-It is also possible to run using the obsolete classic implementation of
-PyMuPDF if it is available as the `fitz_old` module. This is done by setting
-PYTHONPATH.
-
 Example usage:
 
     ./PyMuPDF/tests/run_compound.py python -m pytest -s PyMuPDF
 
 Use `-i <implementations>` to select which implementations to use. In
 `<implementations>`, `r` means rebased, `R` means rebased without
-optimisations, `c` means classic.
+optimisations.
 
 For example use the rebased and unoptimised rebased implementations with:
 
@@ -64,7 +60,6 @@ def main():
         i += 1
     args = sys.argv[i:]
     
-    e_classic = None
     e_rebased = None
     e_rebased_unoptimised = None
     
@@ -76,9 +71,7 @@ def main():
     implementations_seen = set()
     for i in implementations:
         assert i not in implementations_seen, f'Duplicate implementation {i!r} in {implementations!r}.'
-        if i == 'c':
-            name = 'classic'
-        elif i == 'r':
+        if i == 'r':
             name = 'rebased'
         elif i == 'R':
             name = 'rebased (unoptimised)'
@@ -92,33 +85,7 @@ def main():
         timeout = None
         if endtime:
             timeout = max(0, endtime - time.time())
-        if i == 'c':
-            # Run with `fitz_old` (classic). We create a file fitz.py that does `from fitz_old
-            # import *` and prepend it to PYTHONPATH. So `import fitz` will actually
-            # import fitz_old as fitz.
-            #
-            d = os.path.abspath( f'{__file__}/../resources')
-    
-            # [Must not do `d = os.path.relpath(d)` because it fails on Windows if
-            # __file__ is on different drive from cwd.]
-    
-            with open( f'{d}/fitz.py', 'w') as f:
-                f.write( textwrap.dedent( f'''
-                        #import sys
-                        #print(f'{{__file__}}: {{sys.path=}}')
-                        #print(f'{{__file__}}: Importing * from fitz_old')
-                        #sys.stdout.flush()
-                        from fitz_old import *
-                        '''))
-    
-            env = os.environ.copy()
-            pp = env.get( 'PYTHONPATH')
-            pp = d if pp is None else f'{d}:{pp}'
-            env[ 'PYTHONPATH'] = pp
-            log_star(f'Running using fitz_old (classic), PYTHONPATH={pp}: {shlex.join(args)}')
-            e_classic = subprocess.run( args, shell=0, check=0, env=env, timeout=timeout).returncode
-        
-        elif i == 'r':
+        if i == 'r':
     
             # Run with default `pymupdf` (rebased).
             #
@@ -137,14 +104,12 @@ def main():
         else:
             raise Exception(f'Unrecognised implementation {i!r}.')
     
-    if e_classic is not None:
-        log(f'{e_classic=}')
     if e_rebased is not None:
         log(f'{e_rebased=}')
     if e_rebased_unoptimised is not None:
         log(f'{e_rebased_unoptimised=}')
     
-    if e_classic or e_rebased or e_rebased_unoptimised:
+    if e_rebased or e_rebased_unoptimised:
        log('Test(s) failed.')
        return 1
 

--- a/tests/test_codespell.py
+++ b/tests/test_codespell.py
@@ -44,8 +44,11 @@ def test_codespell():
             ''')
     skips = skips.strip().replace('\n', ',')
     
-    command = f'cd {root} && codespell --skip {shlex.quote(skips)} --count'
-    command += f' --ignore-words-list re-use,flate,thirdparty'
+    command = textwrap.dedent(f'''
+            cd {root} && codespell
+                --skip {shlex.quote(skips)}
+                --ignore-words-list re-use,flate,thirdparty
+            ''')
     
     sys.path.append(root)
     try:
@@ -56,11 +59,16 @@ def test_codespell():
     
     for p in git_files:
         _, ext = os.path.splitext(p)
-        if ext in ('.png', '.pdf'):
+        if ext in ('.png', '.pdf', '.jpg', '.svg'):
             pass
         else:
-            command += f' {p}'
+            command += f'    {p}\n'
     
-    print(f'test_codespell(): Running: {command}')
+    if platform.system() != 'Windows':
+        command = command.replace('\n', ' \\\n')
+    # Don't print entire command because very long, and will be displayed
+    # anyway if there is an error.
+    #print(f'test_codespell(): Running: {command}')
+    print(f'Running codespell.')
     subprocess.run(command, shell=1, check=1)
     print('test_codespell(): codespell succeeded.')


### PR DESCRIPTION
* Removed support for build/test of classic implementation.
* scripts/gh_release.py: include mupdf-devel in all PyMuPDFb wheels.
* setup.py: optimise building of PyMuPDFd wheels.
* tests/test_codespell.py: improve output diagnostics.
* docs/pymupdf4llm/api.rst: fix typo spotted by our codespell test.