### PR TITLE
Correctly locate tessdata from installation folder

### DIFF
--- a/tests/test_tesseract.py
+++ b/tests/test_tesseract.py
@@ -65,3 +65,4 @@ def test_tesseract():
                         'dropping unclosed output'
                         )
         
+


### PR DESCRIPTION
If tesseract-ocr is not version 4.00 in a Unix-like platform, we incorrectly used pathlib.Path for locating tessdata.
This fix correctly determines the tessdata folder name for any version of tesseract-ocr.
Note however, that we do not guarantee that MuPDF's own OCR code (which is on Tesseract version 4.00) can cope with tessdata content for a different version than 4.00.