### PR TITLE
Two Changes

### DIFF
--- a/docs/document.rst
+++ b/docs/document.rst
@@ -1223,7 +1223,7 @@ For details on **embedded files** refer to Appendix 3.
      * 2 = fonts
      * 255 = all
 
-    :arg bool linear: Save a linearised version of the document. This option creates a file format for improved performance for Internet access. Excludes "incremental".
+    :arg bool linear: Save a linearised version of the document. This option creates a file format for improved performance for Internet access. Excludes "incremental" and "use_objstms".
 
     :arg bool pretty: Prettify the document source for better readability. PDF objects will be reformatted to look like the default output of :meth:`Document.xref_object`.
 
@@ -1245,7 +1245,7 @@ For details on **embedded files** refer to Appendix 3.
 
       **File size reduction**
 
-      1. Use the save options like `garbage=3|4, deflate=True, use_objstms=True|1`. Do not touch the default values `expand=False|0, clean=False|0, incremental=False|0`.
+      1. Use the save options like `garbage=3|4, deflate=True, use_objstms=True|1`. Do not touch the default values `expand=False|0, clean=False|0, incremental=False|0, linear=False|0`.
       This is a "lossless" file size reduction. There is a convenience version of this method with these values set by default, :meth:`Document.ez_save` -- please see below. 
 
       2. "Lossy" file size reduction in essence must give up something with respect to images, like (a) remove all images (b) replace images by their grayscale versions (c) reduce image resolutions. Find examples in the `PyMuPDF Utilities "replace-image" folder <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/replace-image>`_.


### PR DESCRIPTION
1. Exclude concurrent use of "linear" and "use_objstms" when saving documents. Addresses issue 3603.

2. More cautiously extract x, y, zoom values when resolving PDF names structures. Addresses issue 3789.