### PR TITLE
Pixmap.pil() method

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -138,7 +138,7 @@ Notes
 
 * There are no **mandatory** external dependencies. However, some optional feature are available only if additional components are installed:
 
-  * `Pillow <https://pypi.org/project/Pillow/>`_ is required for :meth:`Pixmap.pil_save` and :meth:`Pixmap.pil_tobytes`.
+  * `Pillow <https://pypi.org/project/Pillow/>`_ is required for :meth:`Pixmap.pil`, :meth:`Pixmap.pil_save` and :meth:`Pixmap.pil_tobytes`.
   * `fontTools <https://pypi.org/project/fonttools/>`_ is required for :meth:`Document.subset_fonts`.
   * `pymupdf-fonts <https://pypi.org/project/pymupdf-fonts/>`_ is a collection of nice fonts to be used for text output methods.
   * `Tesseract-OCR <https://github.com/tesseract-ocr/tesseract>`_ for optical character recognition in images and document pages. Tesseract is separate software, not a Python package. To enable OCR functions in PyMuPDF, the software must be installed and the system environment variable `"TESSDATA_PREFIX"` must be defined and contain the `tessdata` folder name of the Tesseract installation location. See below.

--- a/docs/locales/ja/LC_MESSAGES/installation.po
+++ b/docs/locales/ja/LC_MESSAGES/installation.po
@@ -196,7 +196,7 @@ msgstr "必須の外部依存関係はありません。ただし、追加のコ
 #: ../../installation.rst:95 c678cc3a473f4c568fdfc4452ba213c8
 msgid ""
 "`Pillow <https://pypi.org/project/Pillow/>`_ is required for "
-":meth:`Pixmap.pil_save` and :meth:`Pixmap.pil_tobytes`."
+":meth:`Pixmap.pil`, :meth:`Pixmap.pil_save` and :meth:`Pixmap.pil_tobytes`."
 msgstr ""
 "`Pillow <https://pypi.org/project/Pillow/>`_ は :meth:`Pixmap.pil_save` と "
 ":meth:`Pixmap.pil_tobytes` の実行に必要です。"

--- a/docs/pixmap.rst
+++ b/docs/pixmap.rst
@@ -387,6 +387,13 @@ Have a look at the :ref:`FAQ` section to see some pixmap usage "at work".
                   imgpdf.close()
                doc.save("ocr-images.pdf")
 
+   ..  method:: pil()
+
+      * New in FIXME
+
+      Convert the pixmap to Pillow format. Returns a `PIL.Image` object. This method is useful for further processing with Pillow.
+
+      :raises ImportError: if Pillow is not installed.
 
    ..  method:: pil_save(*args, unmultiply=False, **kwargs)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10153,12 +10153,8 @@ class Pixmap:
         self.pdfocr_save(bio, compress=compress, language=language, tessdata=tessdata)
         return bio.getvalue()
 
-    def pil_save(self, *args, **kwargs):
-        """Write to image file using Pillow.
-
-        Args are passed to Pillow's Image.save method, see their documentation.
-        Use instead of save when other output formats are desired.
-        """
+    def pil(self):
+        """Convert to a PIL/Pillow image."""
         try:
             from PIL import Image
         except ImportError:
@@ -10175,7 +10171,15 @@ class Pixmap:
         else:
             mode = "CMYK"
 
-        img = Image.frombytes(mode, (self.width, self.height), self.samples)
+        return Image.frombytes(mode, (self.width, self.height), self.samples)
+
+    def pil_save(self, *args, **kwargs):
+        """Write to image file using Pillow.
+
+        Args are passed to Pillow's Image.save method, see their documentation.
+        Use instead of save when other output formats are desired.
+        """
+        img = self.pil()
 
         if "dpi" not in kwargs.keys():
             kwargs["dpi"] = (self.xres, self.yres)


### PR DESCRIPTION
`Pixmap.pil_save()` and `Pixmap.pil_tobytes()` methods convert a `Pixmap` to a `PIL.Image` object internally, but don't expose this object to the user of the library. Having access to the Pillow object directly is very useful to apply your own image processing to the pixmap or interface with another library that requires Pillow objects as input. I added a method, `Pixmap.pil()` to do exactly that, simply convert a `Pixmap` to a `PIL.Image`