### PR TITLE
tests/: test_2608(): (red)add expected result

### DIFF
--- a/tests/resources/test_2608_expected-1.24.x
+++ b/tests/resources/test_2608_expected-1.24.x
@@ -1,0 +1,10 @@
+No significant gamma-ray excess above the expected background
+is detected from the direction of FRB 20171019A, with 52 gamma
+candidate events from the source region and 524 background event.
+A second analysis using an independent event calibration and reconstruction (Parsons & Hinton 2014) confirms this result. A search for
+variable emission on timescales ranging from milliseconds to several minutes with tools provided in (Brun et al. 2020) does not reveal
+any variability above 2.2 𝜎. For the total data set of 1.8 h, 95% confidence level (C. L.) upper limits on the photon flux are derived using
+the method described by Rolke et al. (2005). The energy threshold
+of the data is highly dependent on the zenith angle of the observations. For these observations, the zenith angles range from 15 to 25
+deg, which leads to an energy threshold for the stacked data set of
+𝐸th = 120 GeV. The upper limit on the Very High Energy (VHE)


### PR DESCRIPTION
9ccf1c38 ("tests/: test_2608(): expect different output with mupdf master.", 2024-09-17) changed the result for master but meant to leave in the 1.24.x result. Re-add the file from (prior to) that commit at the newly expected location.