### PR TITLE
Jules

### DIFF
--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -26,4 +26,4 @@ jobs:
         env:
             PYMUDF_SCRIPTS_TEST_options: ${{inputs.scripts_test_options}}
         run:
-          python scripts/test.py -m 'git:--recursive --depth 1 --shallow-submodules --branch master https://github.com/ArtifexSoftware/mupdf.git' --valgrind 1 buildtest
+          python scripts/test.py -m 'git:--recursive --depth 1 --shallow-submodules --branch master https://github.com/ArtifexSoftware/mupdf.git' --valgrind 1 -f 0 -i r buildtest

--- a/scripts/sysinstall.py
+++ b/scripts/sysinstall.py
@@ -119,6 +119,9 @@ def main():
         run_command(f'sudo PATH={os.environ["PATH"]} python -V', check=0)
         run_command(f'sudo PATH={os.environ["PATH"]} python3 -V', check=0)
     
+    if test_py.github_workflow_unimportant():
+        return
+    
     # Set default behaviour.
     #
     use_installer = True

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -129,6 +129,9 @@ pymupdf_dir = os.path.abspath( f'{__file__}/../..')
 
 def main(argv):
 
+    if github_workflow_unimportant():
+        return
+    
     if len(argv) == 1:
         show_help()
         return
@@ -285,6 +288,21 @@ def show_help():
     print(__doc__)
     print(venv_info())
 
+
+def github_workflow_unimportant():
+    '''
+    Returns true if we are running a Github scheduled workflow but in a
+    repository not called 'PyMuPDF'. This can be used to avoid consuming
+    unnecessary Github minutes running workflows on non-main repositories such
+    as ArtifexSoftware/PyMuPDF-julian.
+    '''
+    GITHUB_EVENT_NAME = os.environ.get('GITHUB_EVENT_NAME')
+    GITHUB_REPOSITORY = os.environ.get('GITHUB_REPOSITORY')
+    if GITHUB_EVENT_NAME == 'schedule' and GITHUB_REPOSITORY != 'pymupdf/PyMuPDF':
+            log(f'## This is an unimportant Github workflow: a scheduled event, not in the main repository `pymupdf/PyMuPDF`.')
+            log(f'## {GITHUB_EVENT_NAME=}.')
+            log(f'## {GITHUB_REPOSITORY=}.')
+            return True
 
 def venv_info(pytest_args=None):
     '''


### PR DESCRIPTION
Reduce Github workflow minutes.

Don't run scheduled workflows on non-main repositories.

Don't run valgrind tests on `fitz` alias or unoptimised pure-python implementation.