### PR TITLE
Jules

### DIFF
--- a/pipcl.py
+++ b/pipcl.py
@@ -463,9 +463,10 @@ class Package:
                 `none`.
 
             tag_platform:
-                Third element of wheel tag defined in PEP-425. Default is
-                `os.environ('AUDITWHEEL_PLAT')` if set, otherwise derived
-                from `setuptools.distutils.util.get_platform()` (was
+                Third element of wheel tag defined in PEP-425. Default
+                is `os.environ('AUDITWHEEL_PLAT')` if set, otherwise
+                derived from `sysconfig.get_platform()` (was
+                `setuptools.distutils.util.get_platform(), before that
                 `distutils.util.get_platform()` as specified in the PEP), e.g.
                 `openbsd_7_0_amd64`.
 

--- a/scripts/gh_release.py
+++ b/scripts/gh_release.py
@@ -558,7 +558,7 @@ def venv( command=None, packages=None, quick=False, system_site_packages=False):
     if platform.system() == 'OpenBSD':
         # libclang not available from pypi.org, but system py3-llvm package
         # works. `pip install` should be run with --no-build-isolation and
-        # explicit `pip install swig setuptools psutil`.
+        # explicit `pip install swig psutil`.
         system_site_packages = True
         #ssp = ' --system-site-packages'
         log(f'OpenBSD: libclang not available from pypi.org.')

--- a/scripts/sysinstall.py
+++ b/scripts/sysinstall.py
@@ -63,9 +63,9 @@ Args:
         from a generated wheel. [Otherwise we use `pip install`, which refuses
         to do a system install with `--root /`, referencing PEP-668.]
     -i <implementations>
-        Passed through to scripts/test.py.
+        Passed through to scripts/test.py. Default is 'rR'.
     -f <test-fitz>
-        Passed through to scripts/test.py.
+        Passed through to scripts/test.py. Default is '1'.
     -p <pytest-options>
         Passed through to scripts/test.py.
     -t <names>
@@ -140,8 +140,8 @@ def main():
     pytest_name = None
     test_venv = 'venv-pymupdf-sysinstall-test'
     pip = 'venv'
-    test_fitz = None
-    test_implementations = None
+    test_fitz = '1'
+    test_implementations = 'rR'
     
     # Parse command-line.
     #

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -375,11 +375,12 @@ def build(
         import setup
         names = setup.get_requires_for_build_wheel()
         del sys.path[0]
-        names = ' '.join(names)
-        if venv_quick:
-            log(f'{venv_quick=}: Not installing packages with pip: {names}')
-        else:
-            gh_release.run( f'python -m pip install --upgrade {names}')
+        if names:
+            names = ' '.join(names)
+            if venv_quick:
+                log(f'{venv_quick=}: Not installing packages with pip: {names}')
+            else:
+                gh_release.run( f'python -m pip install --upgrade {names}')
         build_isolation_text = ' --no-build-isolation'
     
     env_extra = dict()

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -46,13 +46,13 @@ Options:
     -d
         Equivalent to `--build-type debug`.
     -f 0|1
-        If 1 (the default) we also test alias `fitz` as well as `pymupdf`.
+        If 1 we also test alias `fitz` as well as `pymupdf`. Default is '0'.
     -i <implementations>
         Set PyMuPDF implementations to test.
         <implementations> must contain only these individual characters:
              'r' - rebased.
              'R' - rebased without optimisations.
-            Default is 'rR'. Also see `PyMuPDF:tests/run_compound.py`.
+            Default is 'r'. Also see `PyMuPDF:tests/run_compound.py`.
     -k <expression>
         Passed straight through to pytest's `-k`.
     -m <location> | --mupdf <location>
@@ -144,8 +144,8 @@ def main(argv):
     build_mupdf = True
     build_flavour = 'pb'
     gdb = False
-    test_fitz = True
-    implementations = None
+    test_fitz = False
+    implementations = 'r'
     test_names = list()
     venv = 2
     pytest_options = None

--- a/setup.py
+++ b/setup.py
@@ -767,9 +767,9 @@ def build_mupdf_windows(
     command += f' -d {windows_build_tail}'
     command += f' -b'
     if PYMUPDF_SETUP_MUPDF_REFCHECK_IF:
-        command += f'--refcheck-if "{PYMUPDF_SETUP_MUPDF_REFCHECK_IF}" '
+        command += f' --refcheck-if "{PYMUPDF_SETUP_MUPDF_REFCHECK_IF}"'
     if PYMUPDF_SETUP_MUPDF_TRACE_IF:
-        command += f'--trace-if "{PYMUPDF_SETUP_MUPDF_TRACE_IF}" '
+        command += f' --trace-if "{PYMUPDF_SETUP_MUPDF_TRACE_IF}"'
     command += f' --devenv "{devenv}"'
     command += f' all'
     if os.environ.get( 'PYMUPDF_SETUP_MUPDF_REBUILD') == '0':
@@ -890,15 +890,15 @@ def build_mupdf_unix(
     command = f'cd {mupdf_local} &&'
     for n, v in env.items():
         command += f' {n}={shlex.quote(v)}'
-    command += f' {sys.executable} ./scripts/mupdfwrap.py -d build/{build_prefix}{build_type} -b '
+    command += f' {sys.executable} ./scripts/mupdfwrap.py -d build/{build_prefix}{build_type} -b'
     if PYMUPDF_SETUP_MUPDF_REFCHECK_IF:
-        command += f'--refcheck-if "{PYMUPDF_SETUP_MUPDF_REFCHECK_IF}" '
+        command += f' --refcheck-if "{PYMUPDF_SETUP_MUPDF_REFCHECK_IF}"'
     if PYMUPDF_SETUP_MUPDF_TRACE_IF:
-        command += f'--trace-if "{PYMUPDF_SETUP_MUPDF_TRACE_IF}" '
+        command += f' --trace-if "{PYMUPDF_SETUP_MUPDF_TRACE_IF}"'
     if 'p' in PYMUPDF_SETUP_FLAVOUR:
-        command += 'all'
+        command += ' all'
     else:
-        command += 'm01'    # No need for C++/Python bindings.
+        command += ' m01'    # No need for C++/Python bindings.
     command += f' && echo {unix_build_dir}:'
     command += f' && ls -l {unix_build_dir}'
 

--- a/setup.py
+++ b/setup.py
@@ -1147,7 +1147,7 @@ if os.path.exists(f'{g_root}/{g_pymupdfb_sdist_marker}'):
     log(f'Specifying dummy PyMuPDFb wheel.')
     
     def get_requires_for_build_wheel(config_settings=None):
-        return ['setuptools']
+        return list()
     
     p = pipcl.Package(
             'PyMuPDFb',
@@ -1252,7 +1252,6 @@ else:
             return r
             
         ret = list()
-        ret.append('setuptools')
         libclang = os.environ.get('PYMUPDF_SETUP_LIBCLANG')
         if libclang:
             print(f'Overriding to use {libclang=}.')

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2812,7 +2812,11 @@ class Document:
                 #   handler = fz_recognize_document(gctx, filetype);
                 #   if (!handler) raise ValueError( MSG_BAD_FILETYPE)
                 # but prefer to leave fz_open_document_with_stream() to raise.
-                doc = mupdf.fz_open_document_with_stream(magic, data)
+                try:
+                    doc = mupdf.fz_open_document_with_stream(magic, data)
+                except Exception as e:
+                    if g_exceptions_verbose > 1:    exception_info()
+                    raise FileDataError(f'Failed to open stream') from e
             else:
                 if filename:
                     if not filetype:
@@ -13168,7 +13172,7 @@ if 1:
                     pass
                 else:
                     #assert not inspect.isroutine(value)
-                    #log(f'importing {name}')
+                    #log(f'importing {_name=} {_value=}.')
                     setattr(_self, _name, _value)
                     #log(f'{getattr( self, name, None)=}')
     else:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1353,3 +1353,14 @@ def test_3859():
             assert type(v)==pymupdf.mupdf.PdfObj, f'`v` is not a pymupdf.mupdf.PdfObj.'
     else:
         assert not hasattr(pymupdf.mupdf, 'PDF_TRUE')
+
+def test_3905():
+    data = b'A,B,C,D\r\n1,2,1,2\r\n2,2,1,2\r\n'
+    try:
+        document = pymupdf.open(stream=data)
+    except pymupdf.FileDataError as e:
+        pass
+    else:
+        assert 0
+    wt = pymupdf.TOOLS.mupdf_warnings()
+    assert wt == 'format error: cannot recognize version marker\ntrying to repair broken xref\nrepairing PDF document'

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1346,8 +1346,7 @@ def test_3859():
         print(f'{pymupdf.mupdf.PDF_NULL=}.')
         print(f'{pymupdf.mupdf.PDF_TRUE=}.')
         print(f'{pymupdf.mupdf.PDF_FALSE=}.')
-        print(f'{pymupdf.mupdf.PDF_LIMIT=}.')
-        for name in ('NULL', 'TRUE', 'FALSE', 'LIMIT'):
+        for name in ('NULL', 'TRUE', 'FALSE'):
             name2 = f'PDF_{name}'
             v = getattr(pymupdf.mupdf, name2)
             print(f'{name=} {name2=} {v=} {type(v)=}')


### PR DESCRIPTION
add control over building MuPDF with refcheck and tracing code.
removed mention of mupdf.PDF_LIMIT, which has been removed.
improve exception if fz_open_document_with_stream() fails.
do not test unoptimised and `fitz` module by default.

Plus various minor fixes to docs etc.