### PR TITLE
Prevent working with empty document

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5281,6 +5281,8 @@ class Document:
 
         Arguments have the same meaning as for the range() built-in.
         """
+        if not self.page_count:
+            raise ValueError("document has no pages")
         # set the start value
         start = start or 0
         while start < 0:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5282,7 +5282,7 @@ class Document:
         Arguments have the same meaning as for the range() built-in.
         """
         if not self.page_count:
-            raise ValueError("document has no pages")
+            return
         # set the start value
         start = start or 0
         while start < 0:


### PR DESCRIPTION
Prevent page iterations if document has zero pages.