### PR TITLE
remove scrubbing of font name

### DIFF
--- a/.github/workflows/python-package-ubuntu.yml
+++ b/.github/workflows/python-package-ubuntu.yml
@@ -1,0 +1,44 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest # ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    # - name: Lint with flake8
+    #   run: |
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    # - name: Test with pytest
+    #   run: |
+    #     pytest
+    - name: Build
+    
+    

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16548,17 +16548,18 @@ def JM_make_spanlist(line_dict, line, raw, buff, tp_rect):
                 ):
             continue
 
-        flags = JM_char_font_flags(mupdf.FzFont(mupdf.ll_fz_keep_font(ch.m_internal.font)), line, ch)
+        fz_font = mupdf.FzFont(mupdf.ll_fz_keep_font(ch.m_internal.font))
+        flags = JM_char_font_flags(fz_font, line, ch)
         origin = mupdf.FzPoint(ch.m_internal.origin)
         style.size = ch.m_internal.size
         style.flags = flags
-        style.font = JM_font_name(mupdf.FzFont(mupdf.ll_fz_keep_font(ch.m_internal.font)))
+        style.font = fz_font
         if mupdf_version_tuple >= (1, 26):
             style.color = ch.m_internal.argb
         else:
             style.color = ch.m_internal.color
-        style.asc = JM_font_ascender(mupdf.FzFont(mupdf.ll_fz_keep_font(ch.m_internal.font)))
-        style.desc = JM_font_descender(mupdf.FzFont(mupdf.ll_fz_keep_font(ch.m_internal.font)))
+        style.asc = JM_font_ascender(fz_font)
+        style.desc = JM_font_descender(fz_font)
 
         if (style.size != old_style.size
                 or style.flags != old_style.flags
@@ -18736,7 +18737,7 @@ def jm_trace_text_span(dev, span, type_, ctm, colorspace, color, alpha, seqno):
     span = mupdf.FzTextSpan( span)
     assert isinstance( ctm, mupdf.fz_matrix)
     ctm = mupdf.FzMatrix( ctm)
-    fontname = JM_font_name( span.font())
+    fontname = span.font()
     #float rgb[3];
     #PyObject *chars = PyTuple_New(span->len);
     

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16702,7 +16702,7 @@ def JM_make_textpage_dict(tp, page_dict, raw):
     block_list = []
     tp_rect = mupdf.FzRect(tp.m_internal.mediabox)
     block_n = -1
-    #log( 'JM_make_textpage_dict {=tp}')
+    #  log( 'JM_make_textpage_dict {=tp}')
     for block in tp:
         block_n += 1
         if (not mupdf.fz_contains_rect(tp_rect, mupdf.FzRect(block.m_internal.bbox))


### PR DESCRIPTION
In get_text, I'm expecting the font names to match the same font names from the get_fonts (get_page_fonts). The resulting fonts are different. If the end user wants "scrubbed" font names, applying the scrubbed at the end makes more sense. I don't believe this will break APIs.

For context, having the full font name (AABDFA+Helvetica) is incredibly useful for analyzing PDFs. without it, a lot of the ability is gone.