### PR TITLE
fix: update to use argb for MuPDF 1.25+ compatibility

### DIFF
--- a/src/extra.i
+++ b/src/extra.i
@@ -3064,7 +3064,7 @@ mupdf::FzRect JM_make_spanlist(
         style.size = ch.m_internal->size;
         style.flags = flags;
         style.font = JM_font_name(ch.m_internal->font);
-        #if (FZ_VERSION_MAJOR > 1 || (FZ_VERSION_MAJOR == 1 && FZ_VERSION_MINOR >= 26))
+        #if (FZ_VERSION_MAJOR > 1 || (FZ_VERSION_MAJOR == 1 && FZ_VERSION_MINOR >= 25))
             style.color = ch.m_internal->argb;
         #else
             style.color = ch.m_internal->color;


### PR DESCRIPTION
relates to 
- https://github.com/ArtifexSoftware/mupdf/commit/3937b650f246b2cc8e8c2f2239b8a8cf949a6d70
- https://github.com/Homebrew/homebrew-core/pull/199417
