### PR TITLE
Address 4186

### DIFF
--- a/docs/page.rst
+++ b/docs/page.rst
@@ -1378,22 +1378,22 @@ In a nutshell, this is what you can do with PyMuPDF:
 
    .. method:: get_text(option,*, clip=None, flags=None, textpage=None, sort=False, delimiters=None)
 
-      Retrieves the content of a page in a variety of formats. This is a wrapper for multiple :ref:`TextPage` methods by choosing the output option `opt` as follows:
+      Retrieves the content of a page in a variety of formats. Depending on the ``flags`` value, this may include text, images and several other object types. The method is a wrapper for multiple :ref:`TextPage` methods by choosing the output option `opt` as follows:
 
-      * "text" -- :meth:`TextPage.extractTEXT`, default
-      * "blocks" -- :meth:`TextPage.extractBLOCKS`
-      * "words" -- :meth:`TextPage.extractWORDS`
-      * "html" -- :meth:`TextPage.extractHTML`
-      * "xhtml" -- :meth:`TextPage.extractXHTML`
-      * "xml" -- :meth:`TextPage.extractXML`
-      * "dict" -- :meth:`TextPage.extractDICT`
-      * "json" -- :meth:`TextPage.extractJSON`
-      * "rawdict" -- :meth:`TextPage.extractRAWDICT`
-      * "rawjson" -- :meth:`TextPage.extractRAWJSON`
+      * "text" -- :meth:`TextPage.extractTEXT`, default. Always includes **text only.**
+      * "blocks" -- :meth:`TextPage.extractBLOCKS`. Includes text and **may** include image meta information.
+      * "words" -- :meth:`TextPage.extractWORDS`. Always includes **text only.**
+      * "html" -- :meth:`TextPage.extractHTML`. May include text and images.
+      * "xhtml" -- :meth:`TextPage.extractXHTML`. May include text and images.
+      * "xml" -- :meth:`TextPage.extractXML`. Always includes **text only.**
+      * "dict" -- :meth:`TextPage.extractDICT`. May include text and images.
+      * "json" -- :meth:`TextPage.extractJSON`. May include text and images.
+      * "rawdict" -- :meth:`TextPage.extractRAWDICT`. May include text and images.
+      * "rawjson" -- :meth:`TextPage.extractRAWJSON`. May include text and images.
 
       :arg str opt: A string indicating the requested format, one of the above. A mixture of upper and lower case is supported. If misspelled, option "text" is silently assumed.
 
-      :arg rect-like clip: restrict extracted text to this rectangle. If None, the full page is taken. Has **no effect** for options "html", "xhtml" and "xml".
+      :arg rect-like clip: restrict the extraction to this rectangle. If ``None`` (default), the visible part of the page is taken. Any content (text, images) that is **not fully contained** in ``clip`` will be completely omitted. To avoid clipping altogether use ``clip=pymupdf.INFINITE_RECT()``. Only then the extraction will contain all items. This parameter has **no effect** on options "html", "xhtml" and "xml".
 
       :arg int flags: indicator bits to control whether to include images or how text should be handled with respect to white spaces and :data:`ligatures`. See :ref:`TextPreserve` for available indicators and :ref:`text_extraction_flags` for default settings. (New in v1.16.2)
 
@@ -1663,11 +1663,11 @@ In a nutshell, this is what you can do with PyMuPDF:
 
    .. method:: get_image_info(hashes=False, xrefs=False)
 
-      Return a list of meta information dictionaries for all images shown on the page. This works for all document types. Technically, this is a subset of the dictionary output of :meth:`Page.get_text`: the image binary content and any text on the page are ignored.
+      Return a list of meta information dictionaries for all images displayed by the page. This works for all document types.
 
       :arg bool hashes: Compute the MD5 hashcode for each encountered image, which allows identifying image duplicates. This adds the key `"digest"` to the output, whose value is a 16 byte `bytes` object. (New in v1.18.13)
 
-      :arg bool xrefs: **PDF only.** Try to find the :data:`xref` for each image. Implies `hashes=True`. Adds the `"xref"` key to the dictionary. If not found, the value is 0, which means, the image is either "inline" or otherwise undetectable. Please note that this option has an extended response time, because the MD5 hashcode will be computed at least two times for each image with an xref. (New in v1.18.13)
+      :arg bool xrefs: **PDF only.** Try to find the :data:`xref` for each image. Implies `hashes=True`. Adds the `"xref"` key to the dictionary. If not found, the value is 0, which means, the image is either "inline" or its xref is undetectable for some reason. Please note that this option has an extended response time, because the MD5 hashcode will be computed at least two times for each image with an xref. (New in v1.18.13)
 
       :rtype: list[dict]
       :returns: A list of dictionaries. This includes information for **exactly those** images, that are shown on the page -- including *"inline images"*. In contrast to images included in :meth:`Page.get_text`, image **binary content** is not loaded, which drastically reduces memory usage. The dictionary layout is similar to that of image blocks in `page.get_text("dict")`.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4209,6 +4209,7 @@ class Document:
 
         o = mupdf.pdf_dict_geta(obj, PDF_NAME('SMask'), PDF_NAME('Mask'))
         cs_string = mupdf.pdf_dict_geta(obj, PDF_NAME('ColorSpace'), PDF_NAME('CS')).pdf_to_name()
+
         if o.m_internal:
             smask = mupdf.pdf_to_num(o)
 
@@ -4216,17 +4217,21 @@ class Document:
             img_type = mupdf.FZ_IMAGE_JPX
             res = mupdf.pdf_load_stream(obj)
             ext = "jpx"
+
         if JM_is_jbig2_image(obj):
             img_type = mupdf.FZ_IMAGE_JBIG2
             res = mupdf.pdf_load_stream(obj)
             ext = "jb2"
-        res = mupdf.pdf_load_raw_stream(obj)
+
+        # if not already determined here, load the raw stream for recognition
         if img_type == mupdf.FZ_IMAGE_UNKNOWN:
             res = mupdf.pdf_load_raw_stream(obj)
             _, c = mupdf.fz_buffer_storage(res)
             #log( '{=_ c}')
             img_type = mupdf.fz_recognize_image_format(c)
             ext = JM_image_extension(img_type)
+
+        # the image type may still be unknown here:
         if img_type == mupdf.FZ_IMAGE_UNKNOWN:
             res = None
             img = mupdf.pdf_load_image(pdf, obj)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4256,10 +4256,8 @@ class Document:
                 ext = "png"
         elif ext == "jpeg" and cs_string == "DeviceCMYK":
             # avoid incorrect JPG by inverting pixel color
-            img = mupdf.pdf_load_image(pdf, obj)
             res = mupdf.fz_new_buffer_from_image_as_jpeg(
-                        img, mupdf.FzColorParams(mupdf.fz_default_color_params),95,1)
-            ext = "jpeg"
+                        img, mupdf.FzColorParams(mupdf.fz_default_color_params), 95, 1)
         else:
             img = mupdf.fz_new_image_from_buffer(res)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4208,6 +4208,7 @@ class Document:
             raise ValueError( "not an image")
 
         o = mupdf.pdf_dict_geta(obj, PDF_NAME('SMask'), PDF_NAME('Mask'))
+        cs_string = mupdf.pdf_dict_geta(obj, PDF_NAME('ColorSpace'), PDF_NAME('CS')).pdf_to_name()
         if o.m_internal:
             smask = mupdf.pdf_to_num(o)
 
@@ -4248,6 +4249,12 @@ class Document:
                         mupdf.FzColorParams(mupdf.fz_default_color_params),
                         )
                 ext = "png"
+        elif ext == "jpeg" and cs_string == "DeviceCMYK":
+            # avoid incorrect JPG by inverting pixel color
+            img = mupdf.pdf_load_image(pdf, obj)
+            res = mupdf.fz_new_buffer_from_image_as_jpeg(
+                        img, mupdf.FzColorParams(mupdf.fz_default_color_params),95,1)
+            ext = "jpeg"
         else:
             img = mupdf.fz_new_image_from_buffer(res)
 
@@ -16521,6 +16528,10 @@ def JM_make_image_block(block, block_dict):
     else:
         buf = mupdf.fz_new_buffer_from_image_as_png(image, mupdf.FzColorParams())
         ext = "png"
+    if ext == "jpeg" and n == 4:  # JPEG and DeviceCMYK
+        buf = mupdf.fz_new_buffer_from_image_as_jpeg(
+                  image,mupdf.FzColorParams(mupdf.fz_default_color_params),
+                  95, 1)
     bytes_ = JM_BinFromBuffer(buf)
     block_dict[ dictkey_width] = w
     block_dict[ dictkey_height] = h

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4209,10 +4209,7 @@ class Document:
 
         o = mupdf.pdf_dict_geta(obj, PDF_NAME('SMask'), PDF_NAME('Mask'))
         cs_string = mupdf.pdf_dict_geta(obj, PDF_NAME('ColorSpace'), PDF_NAME('CS')).pdf_to_name()
-<<<<<<< HEAD
 
-=======
->>>>>>> 4be00558 (Address 4186)
         if o.m_internal:
             smask = mupdf.pdf_to_num(o)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4209,7 +4209,10 @@ class Document:
 
         o = mupdf.pdf_dict_geta(obj, PDF_NAME('SMask'), PDF_NAME('Mask'))
         cs_string = mupdf.pdf_dict_geta(obj, PDF_NAME('ColorSpace'), PDF_NAME('CS')).pdf_to_name()
+<<<<<<< HEAD
 
+=======
+>>>>>>> 4be00558 (Address 4186)
         if o.m_internal:
             smask = mupdf.pdf_to_num(o)
 

--- a/src/extra.i
+++ b/src/extra.i
@@ -3483,6 +3483,9 @@ void JM_make_image_block(fz_stext_block *block, PyObject *block_dict)
             buf = freebuf = fz_new_buffer_from_image_as_png(ctx, image, fz_default_color_params);
             ext = "png";
         }
+        if (n == 4 && strcmp(ext, "jpeg") == 0)  { // JPEG CMYK needs another step
+            buf = freebuf = fz_new_buffer_from_image_as_jpeg(ctx, image, fz_default_color_params, 95, 1);        
+        }
         bytes = JM_BinFromBuffer(buf);
     }
     fz_always(ctx) {


### PR DESCRIPTION
JPEG with CMYK color space need inversion of the pixel colors.
This was an an undetected problem so far.
The fix checks whether we have extracted a JPEG image with color space CMYK, respectively number of components = 4.
If so, we convert / reprocess the image buffer specifying the option "invert_cmyk". As we cannot know the original JPEG quality, the reprocessing uses JPEG quality 95 (close to lossless).
This fix covers cases `Document.extract_image(xref)` as well as `page.get_text("dict")` outputs.

There seems to be no way of verifying the success of this.

Note:
The MuPDF CLI tool `mutool extract` also does it wrong and extracts JPEG/CMYK images with inverted (wrong) colors.