### PR TITLE
Replace pixmap color inversion logic

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10185,8 +10185,10 @@ class Pixmap:
             return False
         r = JM_irect_from_py(bbox)
         if mupdf.fz_is_infinite_irect(r):
-            r = mupdf.fz_pixmap_bbox( pm)
-        return bool(JM_invert_pixmap_rect( pm, r))
+            mupdf.fz_invert_pixmap(pm)
+            return True
+        mupdf.fz_invert_pixmap_rect(pm, r)
+        return True
 
     @property
     def irect(self):
@@ -16281,42 +16283,6 @@ def JM_insert_font(pdf, bfname, fontfile, fontbuffer, set_simple, idx, wmode, se
             },
             ]
     return value
-
-
-def JM_invert_pixmap_rect( dest, b):
-    '''
-    invert a rectangle - also supports non-alpha pixmaps
-    '''
-    assert isinstance( dest, mupdf.FzPixmap)
-    assert isinstance( b, mupdf.FzIrect)
-    b = mupdf.fz_intersect_irect(b, mupdf.fz_pixmap_bbox( dest))
-    w = b.x1 - b.x0
-    y = b.y1 - b.y0
-    if w <= 0 or y <= 0:
-        return 0
-
-    destspan = dest.stride()
-    destp = destspan * (b.y0 - dest.y()) + dest.n() * (b.x0 - dest.x())
-    n0 = dest.n() - dest.alpha()
-    alpha = dest.alpha()
-    while 1:
-        s = destp
-        for x in range( w):
-            for i in range( n0):
-                ss = mupdf.fz_samples_get( dest, s)
-                ss = 255 - ss
-                mupdf.fz_samples_set( dest, s, ss)
-                s += 1
-            if alpha:
-                ss = mupdf.fz_samples_get( dest, s)
-                ss += 1
-                mupdf.fz_samples_set( dest, s, ss)
-        destp += destspan
-        y -= 1
-        if y == 0:
-            break
-    return 1
-
 
 def JM_irect_from_py(r):
     '''


### PR DESCRIPTION
We are currently using our own code for this - which is erroneous and also is very slow (written in Python). This fix falls back to using MuPDF native functions `fz_invert_pixmap` and `fz_invert_pixmap_rect`. This obsoletes function `JM_invert_pixmap_rect` and significantly improves speed.