### PR TITLE
Documentation: Add other offline download options

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,8 +20,7 @@ sphinx:
    configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+formats: all
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Updated `.readthedocs.yaml` to enable all supported offline download options.

Relevant documentation of the available formats:
https://docs.readthedocs.com/platform/stable/config-file/v2.html#formats
https://docs.readthedocs.com/platform/stable/downloadable-documentation.html