### PR TITLE
src/fitz___init__.py: allow access to fitz._globals, for test_4179.

### DIFF
--- a/src/fitz___init__.py
+++ b/src/fitz___init__.py
@@ -9,3 +9,4 @@ from pymupdf import _log_items_active
 from pymupdf import _log_items_clear
 from pymupdf import __version__
 from pymupdf import __doc__
+from pymupdf import _globals


### PR DESCRIPTION
Fixes sysinstall tests.