### PR TITLE
about-feature-matrix: pikepdf supports reading labels

### DIFF
--- a/docs/about-feature-matrix.rst
+++ b/docs/about-feature-matrix.rst
@@ -448,7 +448,7 @@
         <tr>
             <td><cite id="transFM43">PDF Page Labels</cite></td>
             <td class="yes"></td>
-            <td class="no"></td>
+            <td class="limited">Read-only</td>
             <td class="no"></td>
             <td class="no"></td>
             <td class="no"></td>


### PR DESCRIPTION
pikepdf supports reading labels:
https://pikepdf.readthedocs.io/en/latest/topics/pages.html#accessing-page-labels
https://pikepdf.readthedocs.io/en/latest/api/models.html#pikepdf.Page.label