### PR TITLE
fix: check if annotation response is found

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -848,7 +848,7 @@ class Annot:
         page = _pdf_annot_page(annot)
         while 1:
             irt_annot = JM_find_annot_irt(annot)
-            if not irt_annot.m_internal:
+            if not irt_annot:
                 break
             mupdf.pdf_delete_annot(page, irt_annot)
         mupdf.pdf_dict_del(annot_obj, PDF_NAME('Popup'))


### PR DESCRIPTION
Hi,
when I tried to scrub a PDF with annotations and no responses, this line caused a failure (`AttributeError: 'NoneType' object has no attribute 'm_internal'`).

This is the obvious fix and also what is being checked when removing annotations (line 8656).

I did not see any tests, so I did not add any. Lmk if there is something more that needs to be done.