### PR TITLE
adjust to python 3.14

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -419,8 +419,15 @@ def _format_g(value, *, fmt='%g'):
         
 format_g = _format_g
 
+# ByteString is gone from typing in 3.14.
+# collections.abc.Buffer available from 3.12 only
+try:
+    ByteString = typing.ByteString
+except AttributeError:
+    ByteString = bytes | bytearray | memoryview
+
 # Names required by class method typing annotations.
-OptBytes = typing.Optional[typing.ByteString]
+OptBytes = typing.Optional[ByteString]
 OptDict = typing.Optional[dict]
 OptFloat = typing.Optional[float]
 OptInt = typing.Union[int, None]
@@ -3979,7 +3986,7 @@ class Document:
 
     def embfile_add(self,
             name: str,
-            buffer_: typing.ByteString,
+            buffer_: ByteString,
             filename: OptStr =None,
             ufilename: OptStr =None,
             desc: OptStr =None,
@@ -8282,7 +8289,7 @@ class Page:
     def add_file_annot(
             self,
             point: point_like,
-            buffer_: typing.ByteString,
+            buffer_: ByteString,
             filename: str,
             ufilename: OptStr =None,
             desc: OptStr =None,
@@ -18379,7 +18386,7 @@ def get_text_length(text: str, fontname: str ="helv", fontsize: float =11, encod
     raise ValueError("Font '%s' is unsupported" % fontname)
 
 
-def image_profile(img: typing.ByteString) -> dict:
+def image_profile(img: ByteString) -> dict:
     """ Return basic properties of an image.
 
     Args:

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,12 +29,20 @@ point_like = "point_like"
 rect_like = "rect_like"
 matrix_like = "matrix_like"
 quad_like = "quad_like"
+
+# ByteString is gone from typing in 3.14.
+# collections.abc.Buffer available from 3.12 only
+try:
+    ByteString = typing.ByteString
+except AttributeError:
+    ByteString = bytes | bytearray | memoryview
+
 AnyType = typing.Any
 OptInt = typing.Union[int, None]
 OptFloat = typing.Optional[float]
 OptStr = typing.Optional[str]
 OptDict = typing.Optional[dict]
-OptBytes = typing.Optional[typing.ByteString]
+OptBytes = typing.Optional[ByteString]
 OptSeq = typing.Optional[typing.Sequence]
 
 """

--- a/src_classic/fitz_old.i
+++ b/src_classic/fitz_old.i
@@ -321,12 +321,20 @@ point_like = "point_like"
 rect_like = "rect_like"
 matrix_like = "matrix_like"
 quad_like = "quad_like"
+
+# ByteString is gone from typing in 3.14.
+# collections.abc.Buffer available from 3.12 only
+try:
+    ByteString = typing.ByteString
+except AttributeError:
+    ByteString = bytes | bytearray | memoryview
+
 AnyType = typing.Any
 OptInt = typing.Union[int, None]
 OptFloat = typing.Optional[float]
 OptStr = typing.Optional[str]
 OptDict = typing.Optional[dict]
-OptBytes = typing.Optional[typing.ByteString]
+OptBytes = typing.Optional[ByteString]
 OptSeq = typing.Optional[typing.Sequence]
 
 try:
@@ -1342,7 +1350,7 @@ struct Document
             self.xref_set_key(xref, "Params/ModDate", get_pdf_str(date))
             return xref
 
-        def embfile_add(self, name: str, buffer: typing.ByteString,
+        def embfile_add(self, name: str, buffer: ByteString,
                                   filename: OptStr =None,
                                   ufilename: OptStr =None,
                                   desc: OptStr =None,) -> None:
@@ -5964,7 +5972,7 @@ struct Page {
 
 
         def add_file_annot(self, point: point_like,
-            buffer: typing.ByteString,
+            buffer: ByteString,
             filename: str,
             ufilename: OptStr =None,
             desc: OptStr =None,

--- a/src_classic/helper-python.i
+++ b/src_classic/helper-python.i
@@ -1245,7 +1245,7 @@ def planish_line(p1: point_like, p2: point_like) -> Matrix:
     return Matrix(util_hor_matrix(p1, p2))
 
 
-def image_profile(img: typing.ByteString) -> dict:
+def image_profile(img: ByteString) -> dict:
     """ Return basic properties of an image.
 
     Args:

--- a/src_classic/utils.py
+++ b/src_classic/utils.py
@@ -23,12 +23,20 @@ point_like = "point_like"
 rect_like = "rect_like"
 matrix_like = "matrix_like"
 quad_like = "quad_like"
+
+# ByteString is gone from typing in 3.14.
+# collections.abc.Buffer available from 3.12 only
+try:
+    ByteString = typing.ByteString
+except AttributeError:
+    ByteString = bytes | bytearray | memoryview
+
 AnyType = typing.Any
 OptInt = typing.Union[int, None]
 OptFloat = typing.Optional[float]
 OptStr = typing.Optional[str]
 OptDict = typing.Optional[dict]
-OptBytes = typing.Optional[typing.ByteString]
+OptBytes = typing.Optional[ByteString]
 OptSeq = typing.Optional[typing.Sequence]
 
 """


### PR DESCRIPTION
`typing.ByteString` has been deprecated since python 3.12 will be removed in python 3.14. For now, use a union type alias rather than identifying the minimal interface.

Fedora being early birds again - but what a day for that!