### PR TITLE
fix: fixed failing linkDest for file links in following format '#page=1&view=Fit'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1094,7 +1094,7 @@ with open( f'{g_root}/READMErb.md', encoding='utf-8') as f:
 # We generate different wheels depending on g_flavour.
 #
 
-version = '1.23.26'
+version = '1.23.26-hotfix'
 version_b = '1.23.22'
 
 tag_python = None

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6780,7 +6780,10 @@ class linkDest:
                     if ftab[1].startswith("page="):
                         self.kind = LINK_GOTOR
                         self.file_spec = ftab[0]
-                        self.page = int(ftab[1][5:]) - 1
+                        page_part = ftab[1][5:]
+                        if "&" in page_part:
+                            page_part = page_part.split("&")[0]
+                        self.page = int(page_part) - 1
             else:
                 self.is_uri = True
                 self.kind = LINK_LAUNCH

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -21733,7 +21733,7 @@ def int_rc(text):
     return int(text)
 
 VersionFitz = "1.23.10" # MuPDF version.
-VersionBind = "1.23.26" # PyMuPDF version.
+VersionBind = "1.23.26-hotfix" # PyMuPDF version.
 VersionDate = "2024-02-29 00:00:01"
 VersionDate2 = VersionDate.replace('-', '').replace(' ', '').replace(':', '')
 version = (VersionBind, VersionFitz, VersionDate2)

--- a/src_classic/helper-python.i
+++ b/src_classic/helper-python.i
@@ -901,7 +901,10 @@ class linkDest(object):
                     if ftab[1].startswith("page="):
                         self.kind = LINK_GOTOR
                         self.fileSpec = ftab[0]
-                        self.page = int(ftab[1][5:]) - 1
+                        page_part = ftab[1][5:]
+                        if "&" in page_part:
+                            page_part = page_part.split("&")[0]
+                        self.page = int(page_part) - 1
             else:
                 self.isUri = True
                 self.kind = LINK_LAUNCH


### PR DESCRIPTION
`linkDest` class may contain links that contain page information in conjunction with other URI parameters in which case attempt to parse such links fails, this MR fixes the issue in this specific case.