### PR TITLE
setup.py src/: auto-generate pymupdf.pymupdf_version and add git info.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -731,7 +731,17 @@ def build():
                         add('d', f'{header_abs}', f'{to_dir_d}/include/{header_rel}')
     
     # Add a .py file containing location of MuPDF.
-    text = f"mupdf_location='{mupdf_location}'\n"
+    try:
+        sha, comment, diff, branch = git_info(g_root)
+    except Exception as e:
+        log(f'Failed to get git information: {e}')
+        sha, comment, diff, branch = (None, None, None, None)
+    text = ''
+    text += f'mupdf_location = {mupdf_location!r}\n'
+    text += f'pymupdf_version = {version_p!r}\n'
+    text += f'pymupdf_git_sha = {sha!r}\n'
+    text += f'pymupdf_git_diff = {diff!r}\n'
+    text += f'pymupdf_git_branch = {branch!r}\n'
     add('p', text.encode(), f'{to_dir}/_build.py')
     
     # Add single README file.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -375,8 +375,18 @@ def _int_rc(text):
 
 # Basic version information.
 #
-pymupdf_version = "1.26.3"
+# (We use `noqa F401` to avoid flake8 errors such as `F401
+# '._build.mupdf_location' imported but unused`.
+#
+from ._build import mupdf_location      # noqa F401
+from ._build import pymupdf_git_branch  # noqa F401
+from ._build import pymupdf_git_diff    # noqa F401
+from ._build import pymupdf_git_sha     # noqa F401
+from ._build import pymupdf_version     # noqa F401
+
 mupdf_version = mupdf.FZ_VERSION
+
+# Removed in PyMuPDF-1.26.1.
 pymupdf_date = None
 
 # Versions as tuples; useful when comparing versions.

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1946,3 +1946,17 @@ def test_4496():
     path = os.path.normpath(f'{__file__}/../../tests/resources/test_4496.hwpx')
     with pymupdf.open(path) as document:
         print(document.page_count)
+
+
+def test_gitinfo():
+    # This doesn't really test very much, but can be useful to see the current
+    # values.
+    print('')
+    print(f'test_4496():')
+    print(f'{pymupdf.mupdf_location=}')
+    print(f'{pymupdf.mupdf_version=}')
+    print(f'{pymupdf.pymupdf_git_branch=}')
+    print(f'{pymupdf.pymupdf_git_sha=}')
+    print(f'{pymupdf.pymupdf_version=}')
+    print(f'pymupdf.pymupdf_git_diff:\n{textwrap.indent(pymupdf.pymupdf_git_diff, "    ")}')
+    


### PR DESCRIPTION
setup.py:build(): add extra information to the generated _build.py file (which used to contain just mupdf_location):
* PyMuPDF package version.
* Information about git sha, branch and diff (if any).

src/__init__.py: make _build.py's contents available as:
* mupdf_location
* pymupdf_git_branch
* pymupdf_git_diff
* pymupdf_git_sha
* pymupdf_version