### PR TITLE
docs: fix conf after _build.py changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build/
 demo/README.rst
 docs/build
+docs/_build.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,16 +49,8 @@ copyright = "2015-" + str(thisday.year) + ", Artifex"
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-_path = os.path.abspath(f'{__file__}/../../src/__init__.py')
-with open(_path) as f:
-    for line in f:
-        match = re.search('pymupdf_version = "([0-9][.][0-9]+[.][0-9]+(rc[0-9]+)?)"', line)
-        if match:
-            release = match.group(1)
-            print(f'{__file__}: setting version from {_path}: {release}')
-            break
-    else:
-        raise Exception(f'Failed to find `VersionBind = ...` in {_path}')
+from _build import pymupdf_version as release  # noqa F401
+print(f'{__file__}: setting version from _build.py: {release}')
 
 # The short X.Y version
 version = release

--- a/setup.py
+++ b/setup.py
@@ -743,6 +743,8 @@ def build():
     text += f'pymupdf_git_diff = {diff!r}\n'
     text += f'pymupdf_git_branch = {branch!r}\n'
     add('p', text.encode(), f'{to_dir}/_build.py')
+    with open('docs/_build.py', 'w') as f:
+        f.write(text)
     
     # Add single README file.
     if 'p' in PYMUPDF_SETUP_FLAVOUR:


### PR DESCRIPTION
`docs/conf.py` tries to read version info from `src/__init__py` using an expression match. This breaks after e439a0fa ("setup.py src/ tests/: auto-generate pymupdf.pymupdf_version and add git info.", 2025-08-08) makes `src/__init__py` import that info from `_build.py`, which is generated during build in the build directory.

Make the build process generate a copy of `_build.py` in `docs` and let `docs/conf.py` import version info from there.

Alternative fixes:
- pointing `docs/conf.py` at the build directory; this may no longer exist after a wheel build, though
- reading from the generated wheel; oh well ;-)
- installing the build and importing `_build.py` from there; this would mean intermingling build and install steps