### PR TITLE
Insert a space between two separated non-space characters.

### DIFF
--- a/src/extra.i
+++ b/src/extra.i
@@ -2308,6 +2308,8 @@ void JM_print_stext_page_as_text(mupdf::FzBuffer& res, mupdf::FzStextPage& page)
             for (auto line: block)
             {
                 int last_char = 0;
+                int prev_c = 0;         // 2025.10.10
+                float prev_x = 0.0f;    // 2025.10.10
                 for (auto ch: line)
                 {
                     fz_rect chbbox = JM_char_bbox( line, ch);
@@ -2316,7 +2318,18 @@ void JM_print_stext_page_as_text(mupdf::FzBuffer& res, mupdf::FzStextPage& page)
                             )
                     {
                         last_char = ch.m_internal->c;
+                        // 2025.10.10: Insert a space between two separated non-space characters.
+                        if (prev_c > 0 && prev_c != 0x20 && last_char != 0x20)
+                        {
+                            float gap = ch.m_internal->quad.ul.x - prev_x;
+                            if (gap > 0.5f)
+                            {
+                                JM_append_rune(res.m_internal, 0x20);
+                            }
+                        }
                         JM_append_rune(res.m_internal, last_char);
+                        prev_c = last_char;     // 2025.10.10
+                        prev_x = ch.m_internal->quad.ur.x;  // 2025.10.10
                     }
                 }
                 if (last_char != 10 && last_char > 0)


### PR DESCRIPTION
Two non-space characters were separated in the PDF file, but they were not separated when I get texts using page.get_text().
By modifying JM_print_stext_page_as_text() in src/extra.i , I resolved this case.
I attach a sample PDF file for you to reproduce my case.
[2023_insert_18.pdf](https://github.com/user-attachments/files/22841368/2023_insert_18.pdf)
Example codes:
  import pymupdf
  doc = pymupdf.open('2023_insert_18.pdf')
  page = doc[0]
  text = page.get_text()
  print(text)

Before modification: "2023년중세계경제는고금리･고물가지속,"
After modification:  "2023년 중 세계경제는 고금리･고물가 지속,"   <-- This is the correct result.