### PR TITLE
changes.txt setup.py: fix breakage with default mupdf-1.26.11 not bei…

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -4,8 +4,6 @@ Change Log
 
 **Changes in version 1.26.6**
 
-* Use MuPDF-1.26.11.
-
 * Fixed issues:
 
   * **Fixed** `4699 <https://github.com/pymupdf/PyMuPDF/issues/4699>`_: cannot find ExtGState resource

--- a/setup.py
+++ b/setup.py
@@ -1269,7 +1269,7 @@ classifier = [
 # PyMuPDF version.
 version_p = '1.26.6'
 
-version_mupdf = '1.26.11'
+version_mupdf = '1.26.10'
 
 # PyMuPDFb version. This is the PyMuPDF version whose PyMuPDFb wheels we will
 # (re)use if generating separate PyMuPDFb wheels. Though as of PyMuPDF-1.24.11


### PR DESCRIPTION
…ng available yet.

Changing back to mupdf-1.26.10 for now. NB we need to also update changes.txt to match, otherwise
tests/test_release.py:test_release_changelog_mupdf_version() fails.