### PR TITLE
tests/test_general.py: test_4746(): fix call to archive.add().

### DIFF
--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -2184,4 +2184,4 @@ def test_4712m():
 
 def test_4746():
     archive = pymupdf.Archive('.')
-    archive.add('foo', __file__)
+    archive.add(__file__, 'foo')


### PR DESCRIPTION
Previously it only worked if a file `foo` existed in current directory.