### PR TITLE
setup.py: use swig -version instead of swig --version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -726,7 +726,7 @@ def build():
         log(f'Failed to get git information: {e}')
         sha, comment, diff, branch = (None, None, None, None)
     swig = PYMUPDF_SETUP_SWIG or 'swig'
-    swig_version_text = run(f'{swig} --version', capture=1)
+    swig_version_text = run(f'{swig} -version', capture=1)
     m = re.search('\nSWIG Version ([^\n]+)', swig_version_text)
     log(f'{swig_version_text=}')
     assert m, f'Unrecognised {swig_version_text=}'


### PR DESCRIPTION
`swig --version` doesn't seem to be supported in all versions of swig, e.g., FreeBSD and some flavors of Linux. Use `swig -version` instead when querying the CLI tool.

Closes: #4756