### PR TITLE
Revert version change for MuPDF 1.26.11 since the causing commit was …

### DIFF
--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -69,7 +69,7 @@ def test_2608():
             f.write(text.encode('utf8'))
         path_expected = os.path.normpath(f'{__file__}/../../tests/resources/test_2608_expected')
         path_expected_1_26 = os.path.normpath(f'{__file__}/../../tests/resources/test_2608_expected_1.26')
-        if pymupdf.mupdf_version_tuple >= (1, 26, 11):
+        if pymupdf.mupdf_version_tuple >= (1, 27):
             path_expected2 = path_expected
         else:
             path_expected2 = path_expected_1_26


### PR DESCRIPTION
…reverted.

Originally MuPDF 1.26.11 was planned to include both the table hunting code as well as dehyphenation and the new text search interface. This combination of changes caused new behaviour in MuPDF which was adapted for in PyMuPDF commit 23de71837cc944b4421487628e29c2e1e06a7547.

Due to newly found bugs in the dehyphenation and text search code and apprehensiveness about adding these many changes to a stable version it was decided to back these out. That means that the change in PyMuPDF commit 23de71837cc944b4421487628e29c2e1e06a7547 will now fail for MuPDF 1.26.11.

The best is to simply revert the commit, which is exactly what happens here.