### PR TITLE
Adapt tests to fewer bogus font ascent/descent value warnings.

### DIFF
--- a/tests/test_clip_page.py
+++ b/tests/test_clip_page.py
@@ -18,7 +18,8 @@ def test_clip():
     page = doc[0]
     page.clip_to_rect(rect)  # clip the page to the rectangle
     # capture font warning message of MuPDF
-    assert pymupdf.TOOLS.mupdf_warnings() == "bogus font ascent/descent values (0 / 0)"
+    if pymupdf.mupdf_version_tuple < (1, 27):
+        assert pymupdf.TOOLS.mupdf_warnings() == "bogus font ascent/descent values (0 / 0)"
     # extract all text characters and assert that each one
     # has a non-empty intersection with the rectangle.
     chars = [

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -337,4 +337,5 @@ def test_4457():
     # Avoid test failure caused by mupdf warnings.
     wt = pymupdf.TOOLS.mupdf_warnings()
     print(f'{wt=}')
-    assert wt == 'bogus font ascent/descent values (0 / 0)\n... repeated 5 times...'
+    if pymupdf.mupdf_version_tuple < (1, 27):
+        assert wt == 'bogus font ascent/descent values (0 / 0)\n... repeated 5 times...'

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -62,11 +62,8 @@ def test_iswrapped():
     doc = pymupdf.open(filename)
     page = doc[0]
     assert page.is_wrapped
-    wt = pymupdf.TOOLS.mupdf_warnings()
-    if pymupdf.mupdf_version_tuple >= (1, 26, 0):
-        assert wt == 'bogus font ascent/descent values (0 / 0)'
-    else:
-        assert not wt
+    if (1, 26, 0) <= pymupdf.mupdf_version_tuple < (1, 27):
+        assert pymupdf.TOOLS.mupdf_warnings() == 'bogus font ascent/descent values (0 / 0)'
 
 
 def test_wrapcontents():
@@ -82,7 +79,7 @@ def test_wrapcontents():
     rebased = hasattr(pymupdf, 'mupdf')
     if rebased:
         wt = pymupdf.TOOLS.mupdf_warnings()
-        if pymupdf.mupdf_version_tuple >= (1, 26, 0):
+        if (1, 26, 0) <= pymupdf.mupdf_version_tuple < (1, 27):
             assert wt == 'bogus font ascent/descent values (0 / 0)\nPDF stream Length incorrect'
         else:
             assert wt == 'PDF stream Length incorrect'
@@ -246,11 +243,8 @@ def test_get_text_dict():
     blocks=page.get_text("dict")["blocks"]
     # Check no opaque types in `blocks`.
     json.dumps( blocks, indent=4)
-    wt = pymupdf.TOOLS.mupdf_warnings()
-    if pymupdf.mupdf_version_tuple >= (1, 26, 0):
-        assert wt == 'bogus font ascent/descent values (0 / 0)'
-    else:
-        assert not wt
+    if (1, 26, 0) <= pymupdf.mupdf_version_tuple < (1, 27):
+        assert pymupdf.TOOLS.mupdf_warnings() == 'bogus font ascent/descent values (0 / 0)'
 
 def test_font():
     font = pymupdf.Font()

--- a/tests/test_pixmap.py
+++ b/tests/test_pixmap.py
@@ -200,7 +200,7 @@ def test_3050():
         else:
             assert rms == 0
         wt = pymupdf.TOOLS.mupdf_warnings()
-        if pymupdf.mupdf_version_tuple >= (1, 26, 0):
+        if (1, 26, 0) <= pymupdf.mupdf_version_tuple < (1, 27):
             assert wt == 'bogus font ascent/descent values (0 / 0)\nPDF stream Length incorrect'
         else:
             assert wt == 'PDF stream Length incorrect'
@@ -523,8 +523,8 @@ def test_4435():
         print(f'Calling page.get_pixmap().', flush=1)
         pixmap = page.get_pixmap(alpha=False, dpi=120)
         print(f'Called page.get_pixmap().', flush=1)
-    wt = pymupdf.TOOLS.mupdf_warnings()
-    assert wt == 'bogus font ascent/descent values (0 / 0)\n... repeated 9 times...'
+    if pymupdf.mupdf_version_tuple < (1, 27):
+        assert pymupdf.TOOLS.mupdf_warnings() == 'bogus font ascent/descent values (0 / 0)\n... repeated 9 times...'
 
 
 def test_4423():


### PR DESCRIPTION
Since MuPDF commit 3d89b00ae59c6ed1f042d77e049a5668b32ca4ca "Only warn about non-zero bad ascender/descender font values" MuPDF no longer warns "bogus font ascent/descent values (0 / 0)". This commit will be part of the upcoming MuPDF 1.27.0, so this commit updates a few pymupdf tests to this new behaviour.