### PR TITLE
Updates workflow .yaml to try to ignore draft PRs.

### DIFF
--- a/.github/workflows/test_quick.yml
+++ b/.github/workflows/test_quick.yml
@@ -15,6 +15,7 @@ jobs:
 
   master:
     name: mupdf master
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -31,6 +32,7 @@ jobs:
 
   release:
     name: mupdf release
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Changes made:
Added `if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'` to both jobs. This condition:

- Skips the job if the PR is a draft
- Still allows the workflow to run when manually triggered via workflow_dispatch

The condition is necessary for both triggers because workflow_dispatch doesn't have a pull_request object, so we need the `|| github.event_name == 'workflow_dispatch'` part to avoid errors if manually running the workflow.