### PR TITLE
Update stale URLs.

### DIFF
--- a/docs/page.rst
+++ b/docs/page.rst
@@ -2004,7 +2004,7 @@ In a nutshell, this is what you can do with PyMuPDF:
 
       * create "n-up" versions of existing PDF files, combining several input pages into **one output page** (see example `combine.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/combine-pages/combine.py>`_),
       * create "posterized" PDF files, i.e. every input page is split up in parts which each create a separate output page (see `posterize.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/posterize-document/posterize.py>`_),
-      * include PDF-based vector images like company logos, watermarks, etc., see `svg-logo.py <https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples/svg-logo.py>`_, which puts an SVG-based logo on each page.
+      * include PDF-based vector images like company logos, watermarks, etc., see `svg.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/insert-logo/svg.py>`_, which puts an SVG-based logo on each page.
 
       :arg rect_like rect: where to place the image on current page. Must be finite and its intersection with the page must not be empty.
       :arg docsrc: source PDF document containing the page. Must be a different document object, but may be the same file.

--- a/docs/pixmap.rst
+++ b/docs/pixmap.rst
@@ -177,7 +177,7 @@ Have a look at the :ref:`FAQ` section to see some pixmap usage "at work".
 
    .. method:: __init__(self, doc, xref)
 
-      **From a PDF image:** Create a pixmap from an image **contained in PDF** *doc* identified by its :data:`xref`. All pimap properties are set by the image. Have a look at `extract-img1.py <https://github.com/pymupdf/PyMuPDF/tree/master/demo/extract-img1.py>`_ and `extract-img2.py <https://github.com/pymupdf/PyMuPDF/tree/master/demo/extract-img2.py>`_ to see how this can be used to recover all of a PDF's images.
+      **From a PDF image:** Create a pixmap from an image **contained in PDF** *doc* identified by its :data:`xref`. All pimap properties are set by the image. Have a look at `extract-from-pages.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/extract-images/extract-from-pages.py>`_ and `extract-from-xref.py <https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/extract-images/extract-from-xref.py>`_ to see how this can be used to recover all of a PDF's images.
 
       :arg doc: an opened |PDF| document.
       :type doc: :ref:`Document`
@@ -674,7 +674,7 @@ psd        gray, rgb, cmyk yes       .psd           Adobe Photoshop Document
 
 .. rubric:: Footnotes
 
-.. [#f1] If you need a **vector image** from the SVG, you must first convert it to a PDF. Try :meth:`Document.convert_to_pdf`. If this is not good enough, look for other SVG-to-PDF conversion tools like the Python packages `svglib <https://pypi.org/project/svglib>`_, `CairoSVG <https://pypi.org/project/cairosvg>`_, `Uniconvertor <https://sk1project.net/modules.php?name=Products&product=uniconvertor&op=download>`_ or the Java solution `Apache Batik <https://github.com/apache/batik>`_. Have a look at our Wiki for more examples.
+.. [#f1] If you need a **vector image** from the SVG, you must first convert it to a PDF. Try :meth:`Document.convert_to_pdf`. If this is not good enough, look for other SVG-to-PDF conversion tools like the Python packages `svglib <https://pypi.org/project/svglib>`_, `CairoSVG <https://pypi.org/project/cairosvg>`_, `Uniconvertor <https://sk1project.net/uc2/download/>`_ or the Java solution `Apache Batik <https://github.com/apache/batik>`_. Have a look at our Wiki for more examples.
 
 .. [#f2] To also set the alpha property, add an additional step to this method by dropping or adding an alpha channel to the result.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -434,13 +434,13 @@ This document also contains a :ref:`FAQ`. This chapter has close connection to t
 .. _toc import (PDF only): https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/import-toc/import.py
 .. _toc export: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/export-toc/export.py
 .. _Vector Image Support page: https://github.com/pymupdf/PyMuPDF/wiki/Vector-Image-Support
-.. _examples: https://github.com/pymupdf/PyMuPDF/tree/master/examples
+.. _examples: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/examples
 .. _Pillow documentation: https://Pillow.readthedocs.io
 .. _here it is!: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/browse-document/browse.py
 .. _PySimpleGUI: https://pypi.org/project/PySimpleGUI/
 .. _demo.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/demo.py
 .. _demo-lowlevel.py: https://github.com/pymupdf/PyMuPDF-Utilities/tree/master/demo/demo-lowlevel.py
-.. _"MuPDF Explored": https://mupdf.com/docs/mupdf-explored.html
+.. _"MuPDF Explored": https://mupdf.com/docs/mupdf_explored.pdf
 .. _Artifex: https://www.artifex.com
 .. _pdf-converter.py: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/convert-document/convert.py
 .. _PDFjoiner.py: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/examples/join-documents/join.py


### PR DESCRIPTION
I ran `linkchecker` and found these stale external URLs.

@JorjMcKie There are two more references, [one to demo.py](https://github.com/pymupdf/PyMuPDF/blob/main/docs/tutorial.rst?plain=1#L441) and [one to demo-lowlevel.py](https://github.com/pymupdf/PyMuPDF/blob/main/docs/tutorial.rst?plain=1#L442), but both [were wiped from PyMuPDF-Utilities](https://github.com/pymupdf/PyMuPDF-Utilities/commit/9a625d3f013df166172dfe3515e5e2bdc4cfe964) and I couldn't locate any matching scripts. Perhaps those sections of tutorial.rst need to be rewritten to refer to the set of new scripts, but that's beyond me. :)