### PR TITLE
Update PyMuPDF to cope with warnings changes in 1.28.0.

### DIFF
--- a/tests/test_2548.py
+++ b/tests/test_2548.py
@@ -32,7 +32,9 @@ def test_2548():
     # This checks that PyMuPDF 1.23.7 fixes this bug, and also that earlier
     # versions with updated MuPDF also fix the bug.
     rebased = hasattr(pymupdf, 'mupdf')
-    if pymupdf.mupdf_version_tuple >= (1, 27):
+    if pymupdf.mupdf_version_tuple >= (1, 28):
+        expected = ''
+    elif pymupdf.mupdf_version_tuple >= (1, 27):
         expected = 'format error: No common ancestor in structure tree\nstructure tree broken, assume tree is missing'
         expected = '\n'.join([expected] * 5)
     else:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -911,11 +911,17 @@ def test_bboxlog_2885():
     
     bbl = page.get_bboxlog()
     wt = pymupdf.TOOLS.mupdf_warnings()
-    assert wt == 'invalid marked content and clip nesting'
+    if pymupdf.mupdf_version_tuple >= (1, 28):
+        assert wt == ''
+    else:
+        assert wt == 'invalid marked content and clip nesting'
     
     bbl = page.get_bboxlog(layers=True)
     wt = pymupdf.TOOLS.mupdf_warnings()
-    assert wt == 'invalid marked content and clip nesting'
+    if pymupdf.mupdf_version_tuple >= (1, 28):
+        assert wt == ''
+    else:
+        assert wt == 'invalid marked content and clip nesting'
 
 def test_3081():
     '''
@@ -1757,7 +1763,10 @@ def test_3569():
                 '</svg>\n'
                 )
     wt = pymupdf.TOOLS.mupdf_warnings()
-    assert wt == 'unknown cid collection: PDFAUTOCAD-Indentity0\nnon-embedded font using identity encoding: ArialMT (mapping via )\ninvalid marked content and clip nesting'
+    if pymupdf.mupdf_version_tuple >= (1, 28):
+        assert wt == 'unknown cid collection: PDFAUTOCAD-Indentity0\nnon-embedded font using identity encoding: ArialMT (mapping via )'
+    else:
+        assert wt == 'unknown cid collection: PDFAUTOCAD-Indentity0\nnon-embedded font using identity encoding: ArialMT (mapping via )\ninvalid marked content and clip nesting'
 
 def test_3450():
     # This issue is a slow-down, so we just show time taken - it's not safe

--- a/tests/test_textextract.py
+++ b/tests/test_textextract.py
@@ -387,7 +387,10 @@ def test_3705():
     assert texts1 == texts0
 
     wt = pymupdf.TOOLS.mupdf_warnings()
-    if pymupdf.mupdf_version_tuple >= (1, 27):
+    if pymupdf.mupdf_version_tuple >= (1, 28):
+        expected = ''
+        assert wt == expected
+    elif pymupdf.mupdf_version_tuple >= (1, 27):
         expected = 'format error: No common ancestor in structure tree\nstructure tree broken, assume tree is missing'
         expected = '\n'.join([expected] * 56)
         assert wt == expected


### PR DESCRIPTION
Text extraction now only produces warnings about corrupt struct trees or layers, if the struct trees or layers are used.