### PR TITLE
Updates Sphinx version to 8.1.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 rst2pdf
 
 # define sphinx versioning
-sphinx==5.3.0
+sphinx==8.1.3
 furo
 readthedocs-sphinx-search==0.3.2
 sphinx_copybutton


### PR DESCRIPTION
This updates the Sphinx version to 8.1.3 to overcome building issues on Python 3.13 - see https://github.com/sphinx-doc/sphinx/issues/10440 
