### PR TITLE
fix: skip widgets with empty or infinite rects in remove_rotation

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11913,8 +11913,13 @@ class Page:
                 pass
         for widget in self.widgets():  # modify field rectangles
             r = widget.rect * rot
+            if r.is_empty or r.is_infinite:
+                continue
             widget.rect = r
-            widget.update()
+            try:
+                widget.update()
+            except ValueError:
+                pass
         return rot  # the inverse of the generated derotation matrix
 
     def cluster_drawings(

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11933,6 +11933,8 @@ class Page:
                 pass
         for widget in self.widgets():  # modify field rectangles
             r = widget.rect * rot
+            if r.is_empty or r.is_infinite:
+                continue
             widget.rect = r
             widget.update()
         return rot  # the inverse of the generated derotation matrix

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -465,3 +465,24 @@ def test_4114():
                 widget.update()
         document.save(path_out)
     assert values == expected_values2
+
+
+def test_4950():
+    with pymupdf.open() as document:
+        page = document.new_page()
+        page.set_rotation(90)
+
+        # Simulate an existing invisible signature field with a zero-dimension
+        # rectangle. Creating such a widget through add_widget() is rejected by
+        # validation, so create a valid widget first and then modify the PDF
+        # object directly.
+        widget = pymupdf.Widget()
+        widget.field_name = "Signature"
+        widget.field_type = pymupdf.PDF_WIDGET_TYPE_SIGNATURE
+        widget.rect = pymupdf.Rect(0, 0, 10, 10)
+        page.add_widget(widget)
+        document.xref_set_key(page.first_widget.xref, "Rect", "[0 0 0 0]")
+        page = document.reload_page(page)
+
+        page.remove_rotation()
+        assert page.rotation == 0


### PR DESCRIPTION
Fixes #4950

remove_rotation() iterates over all widgets and calls widget.update()
after transforming their rect. Widgets with empty or infinite rects
(like invisible signature fields with Rect(0, 0, 0, 0)) cause
ValueError('bad rect') during the internal validation in update().

This skips widgets with empty or infinite rects before the update
call, and wraps widget.update() in a try/except for any remaining
edge cases.