### PR TITLE
Japanese and Korean docs no longer build on RTD due to Python version

### DIFF
--- a/docs/locales/ja/.readthedocs.yaml
+++ b/docs/locales/ja/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.13"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/docs/locales/ko/.readthedocs.yaml
+++ b/docs/locales/ko/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.13"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"


### PR DESCRIPTION
See information from RTD:

<img width="1139" height="458" alt="Screenshot 2026-05-04 at 22 10 20" src="https://github.com/user-attachments/assets/91528756-cf9f-468b-ab69-4f9fb6a88aa3" />


I believe this relates to the Python version defined in requirements.txt