### PR TITLE
remove usage of typing.ByteString

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -462,12 +462,7 @@ def _format_g(value, *, fmt='%g'):
         
 format_g = _format_g
 
-# ByteString is gone from typing in 3.14.
-# collections.abc.Buffer available from 3.12 only
-try:
-    ByteString = typing.ByteString
-except AttributeError:
-    ByteString = bytes | bytearray | memoryview
+ByteString = bytes | bytearray | memoryview
 
 # Names required by class method typing annotations.
 OptBytes = typing.Optional[ByteString]

--- a/src/utils.py
+++ b/src/utils.py
@@ -24,13 +24,8 @@ rect_like = "rect_like"
 matrix_like = "matrix_like"
 quad_like = "quad_like"
 
-# ByteString is gone from typing in 3.14.
-# collections.abc.Buffer available from 3.12 only
-try:
-    ByteString = typing.ByteString
-except AttributeError:
-    # pylint: disable=unsupported-binary-operation
-    ByteString = bytes | bytearray | memoryview
+# pylint: disable=unsupported-binary-operation
+ByteString = bytes | bytearray | memoryview
 
 AnyType = typing.Any
 OptInt = typing.Union[int, None]

--- a/src_classic/fitz_old.i
+++ b/src_classic/fitz_old.i
@@ -322,12 +322,7 @@ rect_like = "rect_like"
 matrix_like = "matrix_like"
 quad_like = "quad_like"
 
-# ByteString is gone from typing in 3.14.
-# collections.abc.Buffer available from 3.12 only
-try:
-    ByteString = typing.ByteString
-except AttributeError:
-    ByteString = bytes | bytearray | memoryview
+ByteString = bytes | bytearray | memoryview
 
 AnyType = typing.Any
 OptInt = typing.Union[int, None]

--- a/src_classic/utils.py
+++ b/src_classic/utils.py
@@ -24,12 +24,7 @@ rect_like = "rect_like"
 matrix_like = "matrix_like"
 quad_like = "quad_like"
 
-# ByteString is gone from typing in 3.14.
-# collections.abc.Buffer available from 3.12 only
-try:
-    ByteString = typing.ByteString
-except AttributeError:
-    ByteString = bytes | bytearray | memoryview
+ByteString = bytes | bytearray | memoryview
 
 AnyType = typing.Any
 OptInt = typing.Union[int, None]


### PR DESCRIPTION
typing.ByteString is deprecated in python 3.15 and slated for removal in python 3.17. This creates deprecation warnings which trip up our tests.

Since we are requiring python >= 3.10 already, we can switch to the proper alternative unconditionally now.