### PR TITLE
src/ tests/: make Document.save() save a pdf for all document types.

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6529,7 +6529,12 @@ class Document:
         if user_pw and len(user_pw) > 40 or owner_pw and len(owner_pw) > 40:
             raise ValueError("password length must not exceed 40")
         
-        pdf = _as_pdf_document(self)
+        pdf = _as_pdf_document(self, required=False)
+        if not pdf:
+            pdf_bytes = self.convert_to_pdf()
+            pdf_document = open(stream=pdf_bytes, filetype='pdf')
+            pdf = _as_pdf_document(pdf_document)
+        
         opts = mupdf.PdfWriteOptions()
         opts.do_incremental = incremental
         opts.do_ascii = ascii

--- a/tests/test_markdown_support.py
+++ b/tests/test_markdown_support.py
@@ -1,5 +1,6 @@
 import pymupdf
 import os
+import textwrap
 
 
 def test_archive_markdown():
@@ -71,3 +72,15 @@ def test_markdown_style():
             assert "Roman" in spans[0]["font"]
         else:
             assert "Roman" not in spans[0]["font"]
+
+def test_markdown_save():
+    md = textwrap.dedent('''
+            # title
+            
+            ## section
+            
+            text
+            ''')
+    with pymupdf.open(stream=md.encode(), filetype='md') as document_md:
+        out_pdf = os.path.normpath(f'{__file__}/../../tests/test_markdown_save.pdf')
+        document_md.save(out_pdf)


### PR DESCRIPTION
If document is not already a pdf, save a temporary pdf created with convert_to_pdf().