### PR TITLE
Fix typo in PyMuPDF (#5042)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ for fmt in ["contract.docx", "data.xlsx", "deck.pptx", "report.hwpx"]:
         print(page.get_text())
 ```
 
-[Get a trial license key for PyMuPDF Pro](https://pymupdf.pro/try-pro?utm_source=github&utm_medium=referral&utm_campaign=pymupdf_github&utm_content=body&utm_term=pymupdf_pro) 
+[Get a trial license key for PyMuPDF Pro](https://pymupdf.pro/try-pro?utm_source=github&utm_medium=referral&utm_campaign=pymupdf_github&utm_content=body&utm_term=pymupdf_pro)
 
 **What you can do with Office documents:**
 

--- a/changes.txt
+++ b/changes.txt
@@ -6,7 +6,7 @@ Change Log
 
 Fixed issues:
 
-* **Fixed** `4114 <https://github.com/pymupdf/PyMuPDF/issues/4114>`_: ComboBox choice_values full of empty strings despite PDF having valid choices. 
+* **Fixed** `4114 <https://github.com/pymupdf/PyMuPDF/issues/4114>`_: ComboBox choice_values full of empty strings despite PDF having valid choices.
 * **Fixed** `4950 <https://github.com/pymupdf/PyMuPDF/issues/4950>`_: remove_rotation() raises ValueError on widgets with empty/infinite rects
 * **Fixed** `5001 <https://github.com/pymupdf/PyMuPDF/issues/5001>`_: Formulae incorrectly rendered as black boxes
 * **Fixed** `5033 <https://github.com/pymupdf/PyMuPDF/issues/5033>`_: Annot.set_rotation(0) followed by Annot.update() throws AttributeError
@@ -58,12 +58,12 @@ Other:
 * Fixed issues:
 
   * **Fixed** `4903 <https://github.com/pymupdf/PyMuPDF/issues/4903>`_: Typing broken because of `*_forward_decl`
-  
+
 * Other:
 
   * Retrospectively marked #4907 as fixed in pymupdf-1.27.1.
   * Improved `get_textpage_ocr()`.
-  
+
     For partial OCR, **all** page areas outside legible text are now OCRed, not
     just those within images. This means that OCR will now also be performed
     for vector graphics, and for text containing illegible characters.
@@ -167,7 +167,7 @@ Other:
   * **Fixed** `4639 <https://github.com/pymupdf/PyMuPDF/issues/4639>`_: pymupdf.mupdf.FzErrorGeneric: code=1: Director error: <class 'AttributeError'>: 'JM_new_bbox_device_Device' object has no attribute 'layer_name'
 
 * Other:
-  
+
   * Check that #4392 `Segfault when running with pytest and -Werror` is fixed if PyMuPDF is built with swig>=4.4.
   * Add `Page.clip_to_rect()`.
   * Improved search for Tesseract data.
@@ -465,7 +465,7 @@ Other:
     so will raise an exception. (#3603)
   * Fixed handling of non-existing /Contents object.
 
- 
+
 **Changes in version 1.24.9 (2024-07-24)**
 
 * Use MuPDF-1.24.8.
@@ -519,11 +519,11 @@ Other:
 * Other:
 
   * Fixed concurrent use of PyMuPDF caused by use of constant temporary filenames.
-  
+
   * Add musllinux x86_64 wheels to release.
 
   * Added clearer version information:
-    
+
     * `pymupdf.pymupdf_version`.
     * `pymupdf.mupdf_version`.
     * `pymupdf.pymupdf_date`.
@@ -603,14 +603,14 @@ Other:
 * Other:
 
   * New/modified methods:
-  
+
     * `Document.bake()`: new, make annotations / fields permanent content.
     * `Page.cluster_drawings()`: new, identifies drawing items
       (i.e. vector graphics or line-art)
       that belong together based on their geometrical vicinity.
     * `Page.apply_redactions()`: added new parameter `text`.
     * `Document.subset_fonts()`: use MuPDF's `pdf_subset_fonts()` instead of PyMuPDF code.
-    
+
   * The `Document` class now supports page numbers specified as slices.
   * Avoid causing MuPDF warnings.
 
@@ -654,11 +654,11 @@ Other:
   * Use MuPDF-1.24.0.
   * Add support for redacting vector graphics.
   * Several fixes for table module
-    
+
     * Add new method for outputting the table as a markdown string.
-    
+
     * Address errors in computing the table header object:
-    
+
       We now allow None as the cell value, because this will be resolved where
       needed (e.g. in the pandas DataFrame).
 
@@ -673,7 +673,7 @@ Other:
 
   * Improved exception text if we fail to open document.
   * Fixed build with new libclang 18.
-  
+
 
 **Changes in version 1.23.26 (2024-02-29)**
 
@@ -685,7 +685,7 @@ Other:
 * Other:
 
   * Improvements to table detection:
-  
+
     * Improved check for empty tables, fixes bugs when determining table headers.
     * Improved computation of enveloping vector graphic rectangles.
     * Ignore more meaningless "pseudo" tables
@@ -794,7 +794,7 @@ Other:
 * Other:
 
   * When finding tables:
-  
+
     * Allow addition of user-defined "virtual" vector graphics when finding tables.
     * Confirm that the enveloping bboxes of vector graphics are inside the clip rectangle.
     * Avoid slow finding of rectangle intersections.
@@ -949,13 +949,13 @@ Other:
   * **Fixed** `2886 <https://github.com/pymupdf/PyMuPDF/issues/2886>`_: Error in Skeleton for Named Link Destinations
 
 * Bug fixes (rebased and classic implementations):
-  
+
   * **Fixed** `2885 <https://github.com/pymupdf/PyMuPDF/issues/2885>`_: pymupdf find tables too slow
 
 * Other:
 
   * Rebased implementation:
-  
+
     * `Page.insert_htmlbox()`: new, much more powerful alternative to `Page.insert_textbox()` or `TextWriter.fill_textbox()`, using `Story`.
     * `Story.fit*()`: new methods for fitting a Story into an expanded rect.
     * `Story.write_with_links()`: add support for external links.
@@ -995,17 +995,17 @@ Other:
 * Other:
 
   * Rebased implementation:
-  
+
     * Added flake8 code checking to test suite, and made various fixes.
     * Disable diagnostics during Document constructor to match classic implementation.
-  
+
   * Additional fix to `2553 <https://github.com/pymupdf/PyMuPDF/issues/2553>`_: Invalid characters in versions >= 1.22
   * Fixed `MuPDF Bug 707324 <https://bugs.ghostscript.com/show_bug.cgi?id=707324>`_: Story: HTML table row background color repeated incorrectly
   * Added `scripts/test.py`, for simple build+test of PyMuPDF git checkout.
   * Added `fitz.pymupdf_version_tuple`, e.g. `(1, 23, 6)`.
   * Restored mistakenly-reverted fix for `2345 <https://github.com/pymupdf/PyMuPDF/issues/2345>`_: Turn off print statements in utils.py
   * Include any trailing `... repeated <N> times...` text in warnings returned by `mupdf_warnings()` (rebased only).
-  
+
 
 
 **Changes in version 1.23.6 (2023-11-06)**
@@ -1127,13 +1127,13 @@ Other:
   * Dropped support for Python-3.7.
 
   * Fix for wrong page / annot `/Contents` cleaning.
-    
+
     We need to set `pdf_filter_options::no_update` to zero.
 
   * Added new function get_tessdata().
 
   * Cope with problem `/Annot` arrays.
-  
+
     When copying page annotations in method Document.insert_pdf we
     previously did not check the validity of members of the `/Annots`
     array.  For faulty members (like null or non-dictionary items) this
@@ -1147,12 +1147,12 @@ Other:
     accordance with MuPDF.
 
   * Increase fault tolerance.
-    
+
     Avoid exceptions in method `insert_pdf()` when source pages contains
     invalid items in the `/Annots` array.
 
   * Return empty border dict for applicable annots.
-    
+
     We previously were returning a non-empty border dictionary even for
     non-applicable annotation types.  We now return the empty dictionary
     `{}` in these cases. This requires some corresponding changes in the
@@ -1165,13 +1165,13 @@ Other:
     annotations and return `False` in these cases.
 
   * Wrong fontsize computation in `page.get_texttrace()`.
-    
+
     When computing the font size we were using the final text
     transformation matrix, where we should have taken `span->trm`
     instead.  This is corrected here.
 
   * Updates to cope with changes to latest MuPDF.
-  
+
     `pdf_lookup_anchor()` has been removed.
 
   * Update fill_textbox to better respect rect.width
@@ -1201,7 +1201,7 @@ Other:
   * **Fixed** `#2430 <https://github.com/pymupdf/PyMuPDF/issues/2430>`_: Incorrectly reducing ref count of Py_None.
   * **Fixed** `#2450 <https://github.com/pymupdf/PyMuPDF/issues/2450>`_: Empty fill color and fill opacity for paths with fill and stroke operations with 1.22.*
   * **Fixed** `#2462 <https://github.com/pymupdf/PyMuPDF/issues/2462>`_: Error at "get_drawing(extended=True )"
-  * **Fixed** `#2468 <https://github.com/pymupdf/PyMuPDF/issues/2468>`_: Decode error when trying to get drawings  
+  * **Fixed** `#2468 <https://github.com/pymupdf/PyMuPDF/issues/2468>`_: Decode error when trying to get drawings
   * **Fixed** `#2710 <https://github.com/pymupdf/PyMuPDF/issues/2710>`_: page.rect and text location wrong / differing from older version
   * **Fixed** `#2723 <https://github.com/pymupdf/PyMuPDF/issues/2723>`_: When will a Python 3.12 wheel be available?
 
@@ -1432,7 +1432,7 @@ Other:
   * Fixed various broken links and typos in docs.
   * Mention install of `swig-python` on MacOS for #875.
   * Added (untested) wheels for macos-arm64.
-  
+
 
 
 

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -42,7 +42,7 @@ The following table illustrates how |PyMuPDF| compares with other typical soluti
     .. image:: images/icons/icon-pptx.svg
             :width: 40
             :height: 40
-            :alt: PPTX icon 
+            :alt: PPTX icon
 
     .. image:: images/icons/icon-hangul.svg
             :width: 40
@@ -70,12 +70,12 @@ The following table illustrates how |PyMuPDF| compares with other typical soluti
 PyMuPDF Product Suite
 -----------------------------------------------
 
-|PyMuPDF| is the standard version of the library, however there are a family of additional products each with different features and functionality. 
+|PyMuPDF| is the standard version of the library, however there are a family of additional products each with different features and functionality.
 
 **Additional products** in the |PyMuPDF| product suite are:
-   
+
 - |PyMuPDF Pro| adds support for Office document formats.
-- |PyMuPDF4LLM| is optimized for large language model (LLM) applications, providing enhanced text extraction and processing capabilities. 
+- |PyMuPDF4LLM| is optimized for large language model (LLM) applications, providing enhanced text extraction and processing capabilities.
  It focuses on layout analysis and semantic understanding, ideal for document conversion and formatting tasks with enhanced results.
 
 .. note::
@@ -91,10 +91,10 @@ PyMuPDF Products Comparison
 The following table illustrates what features the products offer:
 
 .. list-table:: PyMuPDF Products Comparison
-   :widths: 10 30 30 30 
+   :widths: 10 30 30 30
    :header-rows: 1
 
-   * - 
+   * -
      - PyMuPDF
      - PyMuPDF Pro
      - PyMuPDF4LLM
@@ -106,7 +106,7 @@ The following table illustrates what features the products offer:
    * - **Output Documents**
      - Can convert any input document to `PDF`, `SVG` or Image
      - *as PyMuPDF*
-     - *as PyMuPDF* and: 
+     - *as PyMuPDF* and:
        Markdown (`MD`), `JSON` or `TXT`
    * - **Page Analysis**
      - Basic page analysis to return document structure
@@ -127,8 +127,8 @@ The following table illustrates what features the products offer:
    * - **Vector extraction**
      - Vector extraction and clustering
      - *as PyMuPDF*
-     - Superior detection of "picture" areas 
-   * - **Popular RAG Integrations** 
+     - Superior detection of "picture" areas
+   * - **Popular RAG Integrations**
      - Langchain, LlamaIndex
      - *as PyMuPDF*
      - *as PyMuPDF* and with some additional help methods for RAG workflows

--- a/docs/algebra.rst
+++ b/docs/algebra.rst
@@ -103,7 +103,7 @@ For the usual arithmetic operations, numbers are always allowed as second operan
   pymupdf.Rect(6.0, 7.0, 8.0, 9.0)
   >>> 3 in pymupdf.Rect(1, 2, 3, 4)
   True
-  >>> 
+  >>>
 
 The following will create the upper left quarter of a document page rectangle::
 
@@ -111,7 +111,7 @@ The following will create the upper left quarter of a document page rectangle::
   Rect(0.0, 0.0, 595.0, 842.0)
   >>> page.rect / 2
   Rect(0.0, 0.0, 297.5, 421.0)
-  >>> 
+  >>>
 
 The following will deliver the **middle point of a line** that connects two points **p1** and **p2**::
 
@@ -120,7 +120,7 @@ The following will deliver the **middle point of a line** that connects two poin
   >>> mp = (p1 + p2) / 2
   >>> mp
   Point(2356.0, 1571.5)
-  >>> 
+  >>>
 
 Compute the **vector dot product** of two points. You can compute the **cosine of angles** and check orthogonality.
 
@@ -141,7 +141,7 @@ Compute the **vector dot product** of two points. You can compute the **cosine o
   >>> # check orhogonality
   >>> p3 = pymupdf.Point(0, 1)
   >>> # p1 and p3 are orthogonal so, as expected:
-  >>> p1 * p3  
+  >>> p1 * p3
   0.0
 
 
@@ -157,7 +157,7 @@ The second operand of a binary operation can always be "like" the left operand. 
   >>> p1 += (4711, 3141)
   >>> p1
   Point(4712.0, 3143.0)
-  >>> 
+  >>>
 
 To shift a rectangle for 5 pixels to the right, do this::
 

--- a/docs/annot.rst
+++ b/docs/annot.rst
@@ -88,7 +88,7 @@ There is a parent-child relationship between an annotation and its page. If the 
       :rtype: :ref:`Pixmap`
 
       .. note::
-         
+
          * If the annotation has just been created or modified, you should :meth:`Document.reload_page` the page first via `page = doc.reload_page(page)`.
 
          * The pixmap will have *"premultiplied"* pixels if `alpha=True`. To learn about some background, e.g. look for "Premultiplied alpha" `in this online glossary <https://en.wikipedia.org/wiki/Glossary_of_computer_graphics#P>`_.
@@ -245,7 +245,7 @@ There is a parent-child relationship between an annotation and its page. If the 
    .. method:: set_blendmode(blendmode)
 
       * New in v1.16.14
-      
+
       Set the annotation's blend mode. See :ref:`AdobeManual`, page 324 for explanations. The blend mode can also be set in :meth:`Annot.update`.
 
       :arg str blendmode: set the blend mode. Use :meth:`Annot.update` to reflect this in the visual appearance. For predefined values see :ref:`BlendModes`. Use `PDF_BM_Normal` to **remove** a blend mode.
@@ -254,7 +254,7 @@ There is a parent-child relationship between an annotation and its page. If the 
    .. method:: set_name(name)
 
       * New in version 1.16.0
-      
+
       Change the name field of any annotation type. For 'FileAttachment' and 'Text' annotations, this is the icon name, for 'Stamp' annotations the text in the stamp. The visual result (if any) depends on your PDF viewer. See also :ref:`mupdficons`.
 
       :arg str name: the new name.
@@ -295,7 +295,7 @@ There is a parent-child relationship between an annotation and its page. If the 
 
       :arg float width: A non-negative value will change the border line width.
       :arg str style: A value other than `None` will change this border property.
-      :arg sequence dashes: All items of the sequence must be integers, otherwise the parameter is ignored. To remove dashing use: `dashes=[]`. If dashes is a non-empty sequence, "style" will automatically be set to "D" (dashed). 
+      :arg sequence dashes: All items of the sequence must be integers, otherwise the parameter is ignored. To remove dashing use: `dashes=[]`. If dashes is a non-empty sequence, "style" will automatically be set to "D" (dashed).
       :arg int clouds: A value >= 0 will change this property. Use `clouds=0` to remove the cloudy appearance completely. Only annotation types 'Square', 'Circle', and 'Polygon' are supported with this property.
 
    .. method:: set_flags(flags)
@@ -318,7 +318,7 @@ There is a parent-child relationship between an annotation and its page. If the 
    .. method:: delete_responses()
 
       * New in version 1.16.12
-      
+
       Delete annotations referring to this one. This includes any 'Popup' annotations and all annotations responding to it.
 
 
@@ -333,7 +333,7 @@ There is a parent-child relationship between an annotation and its page. If the 
 
    .. method:: update(opacity=None, blend_mode=None, fontsize=0, text_color=None, border_color=None, fill_color=None, cross_out=True, rotate=-1)
 
-      Synchronize the appearance of an annotation with its properties after relevant changes. 
+      Synchronize the appearance of an annotation with its properties after relevant changes.
 
       You can safely **omit** this method **only** for the following changes:
 

--- a/docs/app1.rst
+++ b/docs/app1.rst
@@ -271,15 +271,15 @@ Text Extraction Flags Defaults
 * New in v1.19.6: The default combinations in the following table are now available as Python constants: :data:`TEXTFLAGS_TEXT`, :data:`TEXTFLAGS_WORDS`, :data:`TEXTFLAGS_BLOCKS`, :data:`TEXTFLAGS_DICT`, :data:`TEXTFLAGS_RAWDICT`, :data:`TEXTFLAGS_HTML`, :data:`TEXTFLAGS_XHTML`, :data:`TEXTFLAGS_XML`, and :data:`TEXTFLAGS_SEARCH`. You can now easily modify a default flag, e.g.
 
     - **include** images in a "blocks" output:
-    
+
     `flags = TEXTFLAGS_BLOCKS | TEXT_PRESERVE_IMAGES`
-    
+
     - **exclude** images from a "dict" output:
-    
+
     `flags = TEXTFLAGS_DICT & ~TEXT_PRESERVE_IMAGES`
-    
+
     - set **dehyphenation off** in text searches:
-    
+
     `flags = TEXTFLAGS_SEARCH & ~TEXT_DEHYPHENATE`
 
 


### PR DESCRIPTION
This is a focused change for the cited issue with minimal side effects.

Related to #5042.