### PR TITLE
Fix make_table_dict.

### DIFF
--- a/src/extra.i
+++ b/src/extra.i
@@ -3736,10 +3736,23 @@ void make_table_dict(fz_stext_page *tp, PyObject *table_dict, PyObject *bbox)
         return;
     }
 
+    if (!block)
+    {
+        /* No table structure found. */
+        return;
+    }
     // Check if a table structure was found
-    if (block && block->type == FZ_STEXT_BLOCK_GRID)
+    if (block->type == FZ_STEXT_BLOCK_GRID)
     {
         JM_make_grid_block(block, table_dict);
+        return;
+    }
+    if (block->type == FZ_STEXT_BLOCK_STRUCT &&
+        block->u.s.down &&
+        block->u.s.down->first_block &&
+        block->u.s.down->first_block->type == FZ_STEXT_BLOCK_GRID)
+    {
+        JM_make_grid_block(block->u.s.down->first_block, table_dict);
     }
 
 }


### PR DESCRIPTION
make_table_dict calls fz_find_table_within_bounds, and is supposed to populate a dict with details from the grid block returned.

BUT... we return the struct block for the Table, and the grid block is the first block within that. So update the logic.
