### PR TITLE
Update fz_find_table_within_bounds call for revised API.

### DIFF
--- a/src/extra.i
+++ b/src/extra.i
@@ -3728,7 +3728,11 @@ void make_table_dict(fz_stext_page *tp, PyObject *table_dict, PyObject *bbox)
 
     try
     {
-        block = mupdf::ll_fz_find_table_within_bounds(tp, bounds);
+#if MUPDF_VERSION_GE(1, 28, 1)
+      block = mupdf::ll_fz_find_table_within_bounds(tp, bounds, NULL);
+#else
+      block = mupdf::ll_fz_find_table_within_bounds(tp, bounds);
+#endif
     }
     catch (std::exception&)
     {


### PR DESCRIPTION
The MuPDF C API has changed to take a pointer to an optional options struct. For now we just make PyMuPDF pass NULL so it behaves as before.

Ideally we should offer a way to parse options and pass a populated struct in too, but this is enough to avoid tests dying.