### PR TITLE
Replace removed Python 2 C API macros for SWIG 4.5.0 compatibility

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -21945,7 +21945,7 @@ def JM_set_widget_properties(annot, Widget):
 
     # entry ignored - may be used later
     #
-    #int text_format = (int) PyInt_AsLong(GETATTR("text_format"));
+    #int text_format = (int) PyLong_AsLong(GETATTR("text_format"));
     #
 
     # field label -----------------------------------------------------------

--- a/src/extra.i
+++ b/src/extra.i
@@ -225,7 +225,7 @@ static void messagev(const char* format, va_list va)
     static PyObject* message_fn = PyObject_GetAttrString(pymupdf_module, "message");
     char* text;
     vasprintf(&text, format, va);
-    PyObject* text_py = PyString_FromString(text);
+    PyObject* text_py = PyUnicode_FromString(text);
     PyObject* args = PyTuple_Pack(1, text_py);
     PyObject* ret = PyObject_CallObject(message_fn, args);
     Py_XDECREF(ret);

--- a/src_classic/fitz_old.i
+++ b/src_classic/fitz_old.i
@@ -6805,7 +6805,7 @@ def get_oc_items(self) -> list:
             fz_try(gctx) {
                 pdf_page *page = pdf_page_from_fz_page(gctx, (fz_page *) $self);
                 if (!page) goto finished;  // have no PDF
-                int xref = (int) PyInt_AsLong(PyDict_GetItem(linkdict, dictkey_xref));
+                int xref = (int) PyLong_AsLong(PyDict_GetItem(linkdict, dictkey_xref));
                 if (xref < 1) goto finished;  // invalid xref
                 pdf_obj *annots = pdf_dict_get(gctx, page->obj, PDF_NAME(Annots));
                 if (!annots) goto finished;  // have no annotations

--- a/src_classic/helper-fields.i
+++ b/src_classic/helper-fields.i
@@ -323,7 +323,7 @@ PyObject *JM_listbox_value(fz_context *ctx, pdf_annot *annot)
     pdf_obj *annot_obj = pdf_annot_obj(ctx, annot);
     pdf_obj *optarr = pdf_dict_get(ctx, annot_obj, PDF_NAME(V));
     if (pdf_is_string(ctx, optarr))         // a single string
-        return PyString_FromString(pdf_to_text_string(ctx, optarr));
+        return PyUnicode_FromString(pdf_to_text_string(ctx, optarr));
 
     // value is an array (may have len 0)
     n = pdf_array_len(ctx, optarr);
@@ -609,7 +609,7 @@ void JM_set_widget_properties(fz_context *ctx, pdf_annot *annot, PyObject *Widge
     Py_ssize_t i, n = 0;
     int d;
     PyObject *value = GETATTR("field_type");
-    int field_type = (int) PyInt_AsLong(value);
+    int field_type = (int) PyLong_AsLong(value);
     Py_DECREF(value);
 
     // rectangle --------------------------------------------------------------
@@ -642,7 +642,7 @@ void JM_set_widget_properties(fz_context *ctx, pdf_annot *annot, PyObject *Widge
         dashes = pdf_new_array(ctx, pdf, n);
         for (i = 0; i < n; i++) {
             pdf_array_push_int(ctx, dashes,
-                               (int64_t) PyInt_AsLong(PySequence_ITEM(value, i)));
+                               (int64_t) PyLong_AsLong(PySequence_ITEM(value, i)));
         }
         pdf_dict_putl_drop(ctx, annot_obj, dashes,
                                 PDF_NAME(BS),
@@ -670,7 +670,7 @@ void JM_set_widget_properties(fz_context *ctx, pdf_annot *annot, PyObject *Widge
 
     // entry ignored - may be used later
     /*
-    int text_format = (int) PyInt_AsLong(GETATTR("text_format"));
+    int text_format = (int) PyLong_AsLong(GETATTR("text_format"));
     */
 
     // field label -----------------------------------------------------------
@@ -701,14 +701,14 @@ void JM_set_widget_properties(fz_context *ctx, pdf_annot *annot, PyObject *Widge
     if (field_type == PDF_WIDGET_TYPE_TEXT)
     {
         value = GETATTR("text_maxlen");
-        int text_maxlen = (int) PyInt_AsLong(value);
+        int text_maxlen = (int) PyLong_AsLong(value);
         if (text_maxlen) {
             pdf_dict_put_int(ctx, annot_obj, PDF_NAME(MaxLen), text_maxlen);
         }
         Py_XDECREF(value);
     }
     value = GETATTR("field_display");
-    d = (int) PyInt_AsLong(value);
+    d = (int) PyLong_AsLong(value);
     Py_XDECREF(value);
     pdf_field_set_display(ctx, annot_obj, d);
 
@@ -748,7 +748,7 @@ void JM_set_widget_properties(fz_context *ctx, pdf_annot *annot, PyObject *Widge
 
     // field flags ------------------------------------------------------------
     value = GETATTR("field_flags");
-    int field_flags = (int) PyInt_AsLong(value);
+    int field_flags = (int) PyLong_AsLong(value);
     Py_XDECREF(value);
     if (!PyErr_Occurred()) {
         if (field_type == PDF_WIDGET_TYPE_COMBOBOX) {

--- a/src_classic/helper-xobject.i
+++ b/src_classic/helper-xobject.i
@@ -137,7 +137,7 @@ static void show(const char* prefix, PyObject* obj)
     }
     PyObject* obj_repr = PyObject_Repr( obj);
     PyObject* obj_repr_u = PyUnicode_AsEncodedString( obj_repr, "utf-8", "~E~");
-    const char* obj_repr_s = PyString_AsString( obj_repr_u);
+    const char* obj_repr_s = PyBytes_AsString( obj_repr_u);
     printf( "%s%s\n", prefix, obj_repr_s);
     fflush(stdout);
 }


### PR DESCRIPTION
SWIG was carrying thus macros before version 4.5.0, but they were never necessary in Python 3. Stop using for compatibility with upcoming SWIG 4.5.0.

Suggested-by: Jitka Plesnikova <jplesnik@redhat.com>