### PR TITLE
Fix leaked reference in _as_blocks()

### DIFF
--- a/src/extra.i
+++ b/src/extra.i
@@ -3498,7 +3498,7 @@ int _as_blocks(fz_stext_block *block, fz_rect tp_rect, PyObject *lines, int bloc
             PyTuple_SET_ITEM(litem, 1, Py_BuildValue("f", blockrect.y0));
             PyTuple_SET_ITEM(litem, 2, Py_BuildValue("f", blockrect.x1));
             PyTuple_SET_ITEM(litem, 3, Py_BuildValue("f", blockrect.y1));
-            PyTuple_SET_ITEM(litem, 4, Py_BuildValue("O", text));
+            PyTuple_SET_ITEM(litem, 4, text);
             PyTuple_SET_ITEM(litem, 5, Py_BuildValue("i", block_n));
             PyTuple_SET_ITEM(litem, 6, Py_BuildValue("i", block->type));
             LIST_APPEND(lines, litem);


### PR DESCRIPTION
## Summary

Fixes #5067.

`JM_EscapeStrFromBuffer()` and `PyUnicode_FromFormat()` return new references. In `_as_blocks()`, `text` was wrapped with `Py_BuildValue("O", text)` before being passed to `PyTuple_SET_ITEM()`. The `"O"` format increments the reference count, while `PyTuple_SET_ITEM()` steals the reference it receives, leaving the original reference to `text` unreleased.

This change passes `text` directly to `PyTuple_SET_ITEM()`, transferring ownership to the tuple and avoiding the leaked reference.

## Testing

- Built PyMuPDF successfully after the change.
- Ran the existing test suite successfully.