### PR TITLE
Remove the debug timing loop from Annot.update()

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1625,7 +1625,6 @@ class Annot:
             is_rich_text = mupdf.pdf_dict_get(annot_obj, PDF_NAME("RC"))
             if not is_rich_text:
                 raise ValueError("cannot set border_color if rich_text is False")
-        Annot.update_timing_test()
         CheckParent(self)
         def color_string(cs, code):
             """Return valid PDF color operator for a given color sequence.
@@ -1887,13 +1886,6 @@ class Annot:
             mupdf.pdf_dict_put_text_string(stream, PDF_NAME('Desc'), desc)
             mupdf.pdf_dict_put_text_string(fs, PDF_NAME('Desc'), desc)
 
-    @staticmethod
-    def update_timing_test():
-        total = 0
-        for i in range( 30*1000):
-            total += i
-        return total
-    
     @property
     def vertices(self):
         """annotation vertex points"""


### PR DESCRIPTION
`Annot.update()` unconditionally calls `Annot.update_timing_test()`, a static method that counts to 30,000 in pure Python and returns a sum the caller discards:

```python
# src/__init__.py:1628, inside Annot.update()
Annot.update_timing_test()

# src/__init__.py:1891
@staticmethod
def update_timing_test():
    total = 0
    for i in range( 30*1000):
        total += i
    return total
```

It looks like a benchmark that was committed by accident. It is present in every release from 1.23.0 through 1.28.2 and in current `main`, and absent from 1.22.x, so it appears to have come in with the `src/__init__.py` rewrite.

### Cost

Measured with PyMuPDF 1.27.2.3 on Python 3.14:

* **0.68 ms per `Annot.update()` call.**
* Writing the 212 ink annotations of one 806-page document takes **420 ms, of which 144 ms is this loop**. The remaining `doc.save()` for the same file is 86 ms — so the accidental loop costs more than saving the document.

Because it is pure Python it also holds the GIL, so it cannot be hidden on a worker thread. In an interactive application that writes annotations on the UI thread it is a visible freeze.

### The change

The method is undocumented and had no other callers anywhere in the repository (the only two references were the call and the definition), so this removes both. Happy to trim it to just the call site if you would rather keep the method around.

I checked that a document written with the call removed is byte-identical to one written with it, apart from the trailer's random `/ID`, which differs between any two saves of the same document anyway.