### PR TITLE
Chore: consistent metadata in wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1105,11 +1105,12 @@ version_mupdf = '1.28.2'
 
 # A normal PyMuPDF package.
 
-requires_dist = list()
-if os.environ.get('PYODIDE_ROOT'):
-    # We can't pip install pytest on pyodide, so specify it here.
-    requires_dist.append('pytest')
-    requires_dist.append('pipcl')
+# We can't pip install pytest on pyodide, so specify it here.
+requires_dist = [
+    "pytest ; sys_platform == 'emscripten'",
+    "pipcl ; sys_platform == 'emscripten'",
+]
+
 
 p = pipcl.Package(
         'pymupdf',


### PR DESCRIPTION
I do not fully understand why `pipcl` and `pytest` become project dependencies on pyodide only, but the best way to express that is through environment markers.  Else, wheels uploaded to pypi contain different metadata.  

Cross-platform resolvers like uv and poetry typically just look at one wheel and trust that all have the same requirements: so depending on which they happen to look at: you are either getting pipcl and pytest always installed, or never installed.

Signaling the requirement through static metadata allows the right answer to be reached on all platforms.