### PR TITLE
Fix path traversal via symlink in embedded_get()

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -356,8 +356,8 @@ def embedded_get(args):
     if not args.unsafe and not args.output:
         if os.path.exists(filename):
             sys.exit(f'refusing to overwrite existing file with stored name: {filename}')
-        filename_abs = os.path.abspath(filename)
-        if not filename_abs.startswith(os.getcwd() + os.sep):
+        filename_real = os.path.realpath(filename)
+        if not filename_real.startswith(os.path.realpath(os.getcwd()) + os.sep):
             sys.exit(f'refusing to write stored name outside current directory: {filename}')
     with open(filename, "wb") as output:
         output.write(stream)


### PR DESCRIPTION
os.path.abspath() is purely lexical and does not resolve symbolic links.  A crafted PDF with an embedded filename like "link/pwned.txt", where "link" is a symlink pointing outside cwd, passes the abspath guard but open() follows the symlink at write time.

Replace abspath() with realpath() so the containment check resolves the full symlink chain before comparing against the working directory.
fix #5089 