### PR TITLE
Fix chars_in_rect pairing top-down rects with top/bottom

### DIFF
--- a/src/table.py
+++ b/src/table.py
@@ -200,8 +200,8 @@ def chars_in_rect(CHARS, rect):
         1
         and rect[0] <= c["x0"]
         and c["x1"] <= rect[2]
-        and rect[1] <= c["y0"]
-        and rect[3] >= c["y1"]
+        and rect[1] <= c["top"]
+        and rect[3] >= c["bottom"]
         for c in CHARS
     )
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -939,3 +939,23 @@ def test_find_tables_union_no_layout_degrades_to_line_candidates():
     finally:
         pymupdf._get_layout = original_get_layout_fn
         doc.close()
+
+
+def test_5092():
+    """chars_in_rect must pair a top-down rect with top/bottom, not CTM y0/y1.
+
+    A character whose top/bottom sit inside rect, but whose y0/y1 do not,
+    must still be detected. This matches the has_text() pairing.
+    """
+    from pymupdf.table import chars_in_rect
+
+    char = {
+        "x0": 10.0,
+        "x1": 20.0,
+        "top": 100.0,
+        "bottom": 110.0,
+        "y0": 690.0,
+        "y1": 700.0,
+    }
+    rect = (0.0, 90.0, 30.0, 120.0)  # top-down: top=90, bottom=120
+    assert chars_in_rect([char], rect)


### PR DESCRIPTION
## Summary

- `chars_in_rect()` compared a top-down `rect` (`rect[1]` top, `rect[3]` bottom) against CTM `y0`/`y1`. Short tables and non-identity CTMs then failed the text-in-rect check and were dropped from `find_tables()`.
- Pair `rect[1]`/`rect[3]` with `c["top"]`/`c["bottom"]`, matching `has_text()` in the same file.
- Fixes #5092

## Test plan

- [x] RED then GREEN: synthetic char with `top`/`bottom` inside `rect` and `y0`/`y1` outside is now detected
- [x] `tests/test_tables.py` — `test_5092` and `test_table2` passed